### PR TITLE
tabbar close bug fix

### DIFF
--- a/src/runtime/less/ts-toolbar.less
+++ b/src/runtime/less/ts-toolbar.less
@@ -428,10 +428,19 @@
 			}
 		}
 	}
-	.ts-counter {
+	.ts-counter,.ts-tab-close {
 		.ts-button {
 			padding-right: @ts-unit-double;
 		}
+	}
+	.ts-tab-close {
+		.ts-button {
+			.ts-close-bg {
+				top: 0;
+				right: 0;
+			}	
+		}
+		
 	}
 	.ts-add-tab,.ts-tab-more {
 		.ts-button {


### PR DESCRIPTION
Close icon was at the wrong place in micro tabbar.
@wiredearp @sampi