### PR TITLE
Don't float the Bars in IE9

### DIFF
--- a/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/ts.ui.BarSpirit.js
+++ b/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/ts.ui.BarSpirit.js
@@ -4,11 +4,12 @@
  * @see {ts.ui.TopBarSpirit}
  * @see {ts.ui.ToolBarSpirit}
  * @using {ts.ui.TopBar} TopBar
+ * @using {gui.Client} Client
  * @using {gui.Combo.chained} chained
  * @using {number} UNIT_DOUBLE
  * @using {number} UNIT_TRIPLE
  */
-ts.ui.BarSpirit = (function(TopBar, chained, UNIT_DOUBLE, UNIT_TRIPLE) {
+ts.ui.BarSpirit = (function(TopBar, Client, chained, UNIT_DOUBLE, UNIT_TRIPLE) {
 
 	return ts.ui.Spirit.extend({
 
@@ -26,10 +27,16 @@ ts.ui.BarSpirit = (function(TopBar, chained, UNIT_DOUBLE, UNIT_TRIPLE) {
 			}
 		},
 		
+		/**
+		 * TODO
+		 */
 		hide: function() {
 			alert('TODO!');
 		},
 		
+		/**
+		 * TODO
+		 */
 		show: function() {
 			alert('TODO!');
 		},
@@ -74,11 +81,14 @@ ts.ui.BarSpirit = (function(TopBar, chained, UNIT_DOUBLE, UNIT_TRIPLE) {
 
 		/**
 		 * Setup stuff in mobule breakpoint (the subclass will decide if and when).
+		 * Note that the floating bar is not floating in IE9 because of certain 
+		 * conflicts with JS positioning versus CSS positioning (IE9 must use 
+		 * `left` and `top` in both cases) but IE9 users are after all not mobile.
 		 * TODO: Make sure to also remove the breakpoint listener when we terminate.
 		 */
 		_initbreakpoint: function() {
 			var main = this.$getmain();
-			if(main) {
+			if(main && Client.has3D) {
 				this.sprite.y = 0;
 				this._onbreakpoint();
 				ts.ui.addBreakPointListener(function(newpoint, oldpoint) {
@@ -136,7 +146,7 @@ ts.ui.BarSpirit = (function(TopBar, chained, UNIT_DOUBLE, UNIT_TRIPLE) {
 
 	});
 
-}(ts.ui.TopBar, gui.Combo.chained, ts.ui.UNIT_DOUBLE, ts.ui.UNIT_TRIPLE));
+}(ts.ui.TopBar, gui.Client, gui.Combo.chained, ts.ui.UNIT_DOUBLE, ts.ui.UNIT_TRIPLE));
 
 /**
  * Generate methods `blue` `green` `purple` and so 


### PR DESCRIPTION
@zdlm and @sampi 

IE9: Misplaced TopBar + ToolBar + TabBar was apparently caused by updates to `top` and `left` position performed in *both* JS and CSS (the other browsers would adjust these only in the CSS while the JS would adjust `transform`). I can't test if this fixes the screenshots because the Browserstack client will not install on my machine (I reinstalled it yet again) because of this error:
```
Fatal error: Hostname/IP doesn't match certificate's altnames: "Host: www.browserstack.com. is not in the cert's altnames: DNS:*.browserstack.com, DNS:browserstack.com"
```
Perhaps @zdlm can rerun the shots once this is merged.