### PR TITLE
Evalutate `ts-nolabel` again (for Angular)

### DIFF
--- a/spec/jasmine/ts.js
+++ b/spec/jasmine/ts.js
@@ -43413,6 +43413,17 @@ ts.ui.LabelSpirit = (function using(Client, FieldSpirit, chained, tick, time, co
 		},
 
 		/**
+		 * Angular might sometimes insert the `SPAN` sometimes after `onattach`
+		 * because it likes to do that kind of stuff, so we'll reconfirm the
+		 * missing label after approximately four milliseconds. If this doesn't
+		 * work, we can always move this code to method `_refrehsstyling` :(
+		 */
+		onasync: function() {
+			ts.ui.FormSupportSpirit.prototype.onasync.call(this);
+			this.css.shift(!this.dom.q('span'), 'ts-nolabel');
+		},
+
+		/**
 		 * If the control class has not been applied, we'll ask all fields to
 		 * refresh the styling. Fixes a (rare) glitch in Angular integration.
 		 * @param {gui.Tick} t

--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.LabelSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.LabelSpirit.js
@@ -55,6 +55,17 @@ ts.ui.LabelSpirit = (function using(Client, FieldSpirit, chained, tick, time, co
 		},
 
 		/**
+		 * Angular might sometimes insert the `SPAN` sometimes after `onattach`
+		 * because it likes to do that kind of stuff, so we'll reconfirm the
+		 * missing label after approximately four milliseconds. If this doesn't
+		 * work, we can always move this code to method `_refrehsstyling` :(
+		 */
+		onasync: function() {
+			this.super.onasync();
+			this.css.shift(!this.dom.q('span'), 'ts-nolabel');
+		},
+
+		/**
 		 * If the control class has not been applied, we'll ask all fields to
 		 * refresh the styling. Fixes a (rare) glitch in Angular integration.
 		 * @param {gui.Tick} t


### PR DESCRIPTION
@leo and @sampi 

If the `label > span` was enclosed in an `ng-if`, it would be inserted in the DOM by Angular sometimes later than usual. So we'll just check for the presence of the `span` once again a little later on :face_with_thermometer: