### PR TITLE
[README] Updated Badges for Travis.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-[![Build Status](https://travis-ci.com/Tradeshift/tradeshift-ui.svg?token=RshDHtS73Tukd2xSZzeg&branch=master)](https://travis-ci.com/Tradeshift/tradeshift-ui)
-[![Gitter](https://img.shields.io/badge/gitter-join%20chat-f81a65.svg?style=flat-square)](https://gitter.im/tradeshift-ui/Lobby)
-[![PeerDependencies](https://img.shields.io/david/peer/Tradeshift/tradeshift-ui.svg?style=flat-square)](https://david-dm.org/Tradeshift/tradeshift-ui#info=peerDependencies&view=list)
-[![Dependencies](https://img.shields.io/david/Tradeshift/tradeshift-ui.svg?style=flat-square)](https://david-dm.org/Tradeshift/tradeshift-ui)
-[![DevDependencies](https://img.shields.io/david/dev/Tradeshift/tradeshift-ui.svg?style=flat-square)](https://david-dm.org/Tradeshift/tradeshift-ui#info=devDependencies&view=list)
+<p align="center">
+	[![travis.org Build Status](https://travis-ci.org/Tradeshift/tradeshift-ui.svg)](https://travis-ci.org/Tradeshift/tradeshift-ui)
+	[![travis.com Build Status](https://travis-ci.com/Tradeshift/tradeshift-ui.svg?token=RshDHtS73Tukd2xSZzeg&branch=master)](https://travis-ci.com/Tradeshift/tradeshift-ui)
+	[![Gitter](https://img.shields.io/badge/gitter-join%20chat-f81a65.svg?style=flat-square)](https://gitter.im/tradeshift-ui/Lobby)
+	[![Dependencies](https://david-dm.org/Tradeshift/tradeshift-ui.svg)](https://david-dm.org/Tradeshift/tradeshift-ui/)
+	[![devDependencies](https://img.shields.io/david/dev/Tradeshift/tradeshift-ui.svg?style=flat-square)](https://david-dm.org/Tradeshift/tradeshift-ui/?type=dev)
+</p>
+___
 
 # [Tradeshift UI](http://ui.tradeshift.com)
 


### PR DESCRIPTION
@wiredearp @zdlm 

Once we're building on travis-ci.org instead of .com, all of these cool badges will work because the build info will be public.

Until then, we'll just have to wait.