### PR TITLE
[Dashboard] Correctly recognize a branch build

### DIFF
--- a/tasks/travis-notify-geckoboard/index.js
+++ b/tasks/travis-notify-geckoboard/index.js
@@ -46,7 +46,7 @@ TravisCIEnv.createFromEnv = function(env) {
 TravisCIEnv.prototype.toTextWidgetValue = function(building) {
 	const getBuildTitle = () =>
 		(
-			(this.pr ?
+			((this.pr && this.pr !== 'false') ?
 				'PR #' + this.pr + '<br/> ' + this.prBranch :
 				this.branch)
 		);


### PR DESCRIPTION
@wiredearp @zdlm @sampi

Fixes issue with master builds showing up as `PR #false` on the dashboard.
