### PR TITLE
Don't throw an error when Aside is removed

### DIFF
--- a/spec/runtime/spirits/core-gui@tradeshift.com/ts.ui.AsideSpirit.spec.js
+++ b/spec/runtime/spirits/core-gui@tradeshift.com/ts.ui.AsideSpirit.spec.js
@@ -12,21 +12,20 @@ describe('ts.ui.AsideSpirit', function likethis() {
 		});
 	});
 
-	it('should fail spectacularly when an open aside is nuked', function(done) {
+	it('should remove cover when Aside is spontaneously nuked', function(done) {
 		var spirit, dom = helper.createTestDom();
 		dom.innerHTML = MARKUP;
 		sometime(function later() {
 			spirit = ts.ui.get(dom.querySelector('aside'));
 			spirit.open();
 			sometime(function muchlater() {
-				try {
-					spirit.dom.remove();
-					expect('this should not be evaluated').toBe(true);
-				} catch (exception) {
-					expect(exception).not.toBe(null);
-				}
-				done();
-			}, 1000);
+				spirit.dom.remove();
+				sometime(function verylate() {
+					var cover = ts.ui.get('#ts-asidecover');
+					expect(cover.css.contains('ts-visible')).toBe(false);
+					done();
+				}, 500);
+			}, 500);
 		});
 	});
 

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.AsideSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.AsideSpirit.js
@@ -185,23 +185,23 @@ ts.ui.AsideSpirit = (function using(chained, confirmed, Client, LayoutModel, not
 		},
 
 		/**
-		 * Confirm closed state on detach.
+		 * Make sure the cover is removed if someone
+		 * nukes the Aside without closing it first.
 		 */
 		ondetach: function() {
 			this.super.ondetach();
-			this._confirmstate(this._isreallyopen);
-			if (this._ismodelled()) {
-				this._model.removeObserver(this);
+			if (this._isreallyopen) {
+				this._updateworld(willclose);
+				this._updateworld(didclose);
 			}
 		},
 
 		/**
-		 * Confirm closed state on destruct.
+		 * Remove observers on destruct: TODO: automate this step!
 		 */
 		ondestruct: function() {
 			this.super.ondestruct();
-			this._confirmstate(this._isreallyopen);
-			if (this._ismodelled()) { // TODO: automate this step
+			if (this._ismodelled()) {
 				this._model.removeObserver(this);
 			}
 		},
@@ -636,25 +636,6 @@ ts.ui.AsideSpirit = (function using(chained, confirmed, Client, LayoutModel, not
 				}
 			} else {
 				this.super._confirmposition();
-			}
-		},
-
-		/**
-		 * Throw and/or error if someone nukes
-		 * the Aside without closing it first.
-		 * @param {boolean} stillopen
-		 */
-		_confirmstate: function(stillopen) {
-			if (stillopen) {
-				this._updateworld(willclose);
-				this._updateworld(didclose); // nuke the cover
-				this._confirmstate = function norepeat() {};
-				var cry = this + ' should not be removed from the document while open.';
-				if (gui.debug) {
-					throw new Error(cry); // so that we can write a test for it :)
-				} else {
-					console.error(cry);
-				}
 			}
 		}
 


### PR DESCRIPTION
@wiredearp @zdlm @sampi

Partially fixes issue #88 - let's at least not throw an exception when an open Aside is spontaneously removed from the document.