### PR TITLE
[Table] Fix selection checkbox in Edge

### DIFF
--- a/spec/runtime/spirits/table-gui@tradeshift.com/ts.ui.TableSpirit.spec.js
+++ b/spec/runtime/spirits/table-gui@tradeshift.com/ts.ui.TableSpirit.spec.js
@@ -57,7 +57,7 @@ describe('ts.ui.TableSpirit', function likethis() {
 			});
 		});
 
-		it('should mark the row as selected', function(done) {
+		it('should mark the row as selected and then unselect', function(done) {
 			setup(function(spirit, dom) {
 				spirit.selectable().rows([
 					{cells: ['A', 'D', 'G'], selected: true},
@@ -66,7 +66,13 @@ describe('ts.ui.TableSpirit', function likethis() {
 				]);
 				sometime(function later() {
 					expect(spirit.element.innerHTML).toContain('ts-icon-checkboxon');
-					done();
+					var icon = spirit.element.querySelector('.ts-icon-checkboxon');
+					var butt = icon.parentNode;
+					butt.click();
+					sometime(function evenlater() {
+						expect(spirit.element.innerHTML).not.toContain('ts-icon-checkboxon');
+						done();
+					});
 				});
 			});
 		});

--- a/src/runtime/js/ts.ui/tables/tables-gui@tradeshift.com/spirits/ts.ui.TableSpirit.js
+++ b/src/runtime/js/ts.ui/tables/tables-gui@tradeshift.com/spirits/ts.ui.TableSpirit.js
@@ -1478,6 +1478,9 @@ ts.ui.TableSpirit = (function using(Type, Client, guiArray, DOMPlugin, CSSPlugin
 				}
 			}
 			if (model.selectable) {
+				if (Client.isEdge && elm.className.startsWith('ts-icon-checkbox')) {
+					elm = elm.parentNode; // `pointer-events:none` ignored in Edge 14 :/
+				}
 				if (CSSPlugin.contains(elm, CLASS_SELECTBUTTON)) {
 					this._ongutsclick(elm);
 				} else if (this._contains(this.queryplugin.getmenu(), elm)) {


### PR DESCRIPTION
@wiredearp @zdlm @sampi

Fixes issue #201 - Table checkboxes are not clickable in IE Edge. Even if it is supposed to work, `pointer-events:none` doesn't actually work in Edge 14 :1st_place_medal: and so the click would be registered on the icon instead of the containing button.