### PR TITLE
Jmo/fixes

### DIFF
--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.SideShowSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.SideShowSpirit.js
@@ -671,16 +671,18 @@ ts.ui.SideShowSpirit = (function using(chained, Client, Parser, GuiObject, Color
 					label: panel.label,
 					selected: index === 0,
 					$onselect: function() {
-						that.dom.qall('this > .ts-panel', ts.ui.PanelSpirit).forEach(function(p) {
-							if (p === panel) {
-								p.show();
-								p.$onselect();
-								// TODO: scroll to zero?
-							} else {
-								p.hide();
-							}
-						});
-						that._reflex();
+						if (!that.$destructed) {
+							that.dom.qall('this > .ts-panel', ts.ui.PanelSpirit).forEach(function(p) {
+								if (p === panel) {
+									p.show();
+									p.$onselect();
+									// TODO: scroll to zero?
+								} else {
+									p.hide();
+								}
+							});
+							that._reflex();
+						}
 					}
 				});
 			});

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/channeling/gui.Guide.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/channeling/gui.Guide.js
@@ -342,9 +342,8 @@ gui.Guide = (function using(
 		 * @returns {boolean}
 		 */
 		_handles: function(node, webkithack) {
-			return node && !this._suspended &&
-				(webkithack || DOMPlugin.embedded(node)) &&
-				Type.isElement(node);
+			return node && Type.isElement(node) && !this._suspended &&
+				(webkithack || DOMPlugin.embedded(node));
 		},
 
 		/**

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMCombos.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMCombos.js
@@ -134,28 +134,10 @@ gui.DOMCombos = (function using(
 	});
 
 	/**
-	 * Materialize subtree of `this`.
-	 */
-	var materializeSubBefore = before(function() {
-		// TODO: detach goes here!
-		gui.materializeSub(this);
-	});
-
-	/**
 	 * Spiritualize subtree of `this`
 	 */
 	var spiritualizeSubAfter = after(function() {
 		gui.spiritualizeSub(this);
-	});
-
-	/**
-	 * Detach `this`.
-	 */
-	var parent = null; // TODO: unref this at some point
-	var materializeThisBefore = before(function() {
-		// TODO: detach goes here!
-		parent = this.parentNode;
-		gui.materialize(this);
 	});
 
 	/**
@@ -291,24 +273,24 @@ gui.DOMCombos = (function using(
 		},
 		innerHTML: function(base) {
 			return (
-				ifEnabled( // subtree instantly disposed without calling detach - should probably detach first!
-					ifEmbedded(materializeSubBefore(spiritualizeSubAfter(suspending(base))),
+				ifEnabled(
+					ifEmbedded(detachBefore(spiritualizeSubAfter(suspending(base))),
 					otherwise(base)),
 				otherwise(base))
 			);
 		},
 		outerHTML: function(base) {
 			return (
-				ifEnabled( // subtree instantly disposed without calling detach - should probably detach first!
-					ifEmbedded(materializeThisBefore(spiritualizeParentAfter(suspending(base))),
+				ifEnabled(
+					ifEmbedded(detachBefore(spiritualizeParentAfter(suspending(base))),
 					otherwise(base)),
 				otherwise(base))
 			);
 		},
 		textContent: function(base) {
 			return (
-				ifEnabled( // subtree instantly disposed without calling detach - should probably detach first!
-					ifEmbedded(materializeSubBefore(suspending(base)),
+				ifEnabled(
+					ifEmbedded(detachBefore(suspending(base)),
 					otherwise(base)),
 				otherwise(base))
 			);

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMCombos.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMCombos.js
@@ -141,6 +141,16 @@ gui.DOMCombos = (function using(
 	});
 
 	/**
+	 * outerHTML special: Materialize `this` and erect a reference to the parent
+	 * so that `this` (and all the children) can be spiritualized in next step.
+	 */
+	var parent = null; // TODO: unref this at some point
+	var materializeThisBefore = before(function() {
+		parent = this.parentNode;
+		gui.materialize(this);
+	});
+
+	/**
 	 * Attach parent.
 	 */
 	var spiritualizeParentAfter = after(function() {
@@ -282,7 +292,7 @@ gui.DOMCombos = (function using(
 		outerHTML: function(base) {
 			return (
 				ifEnabled(
-					ifEmbedded(detachBefore(spiritualizeParentAfter(suspending(base))),
+					ifEmbedded(materializeThisBefore(detachBefore(spiritualizeParentAfter(suspending(base)))),
 					otherwise(base)),
 				otherwise(base))
 			);


### PR DESCRIPTION
@wiredearp @zdlm @sampi @sqren @gogozby

Fixes issue #88 "ts-asidecover resides on the page" once and for all: Assuming that devs would not not keep a reference to elements destroyed via `innerHTML` `outerHTML` and `textContent`, I figured back in the days that we might as well dispose any associated spirits instantly without going through the process:

1. Call `detach` on the spirits and mark them outside of the DOM.
2. In next tick, dispose all spirits that we not re-inserted into the DOM.

This would of course mean that `detach` was not called and this has most likely caused the bug :nauseated_face: