### PR TITLE
Detach children (not the element itself) on innerHTML and textContent

### DIFF
--- a/spec/jasmine/helpers.js
+++ b/spec/jasmine/helpers.js
@@ -30,12 +30,12 @@ window.helper = {
 			document.createElement('main')
 		);
 		main.className = 'ts-main';
-		if(Spirit) {
+		if (Spirit) {
 			var spirit = Spirit.summon();
 			spirit.dom.appendTo(main);
 		}
 		afterEach(function cleanup() {
-			if(main.parentNode === document.body) {
+			if (main.parentNode === document.body) {
 				document.body.removeChild(main);
 			}
 		});

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/channeling/gui.Guide.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/channeling/gui.Guide.js
@@ -133,10 +133,12 @@ gui.Guide = (function using(
 		/**
 		 * Invoke ondetach for element spirit and descendants spirits.
 		 * TODO: This sequence should probably be revisited at some point.
+		 * TODO: TODO: Support NodeList and DocumentFragment as argument.
 		 * @param {Element|gui.Spirit} target
+		 * @param @optional {boolean} skip If true, only detach the children
 		 */
-		$detach: function(target) {
-			this._maybedetach(target);
+		$detach: function(target, skip) {
+			this._maybedetach(target, !!skip);
 		},
 
 		/*
@@ -481,11 +483,12 @@ gui.Guide = (function using(
 
 		/**
 		 * @param {Element|gui.Spirit} element
+		 * @param {boolean} skip
 		 */
-		_maybedetach: function(element) {
+		_maybedetach: function(element, skip) {
 			element = Type.isSpirit(element) ? element.element : element;
 			if (this._handles(element)) {
-				this._collect(element, false, gui.CRAWLER_DETACH).forEach(function(spirit) {
+				this._collect(element, skip, gui.CRAWLER_DETACH).forEach(function(spirit) {
 					Spirit.$detach(spirit);
 				});
 			}

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMChanger.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMChanger.js
@@ -112,6 +112,7 @@ gui.DOMChanger = {
 		if (this._ismethod(name)) {
 			this._domethod(proto, name, combo);
 		} else {
+			this._doaccessor(proto, name, combo);
 			if (gui.Client.isGecko) {
 				this._dogeckoaccesor(proto, name, combo, root);
 			} else if (ok) {
@@ -127,7 +128,6 @@ gui.DOMChanger = {
 	 * @returns {boolean}
 	 */
 	_ismethod: function(name) {
-		var is = false;
 		switch (name) {
 			case 'appendChild':
 			case 'removeChild':
@@ -135,12 +135,11 @@ gui.DOMChanger = {
 			case 'replaceChild':
 			case 'setAttribute':
 			case 'removeAttribute':
-			case 'insertAdjecantHTML':
+			case 'insertAdjacentHTML':
 			case 'remove':
-				is = true;
-				break;
+				return true;
 		}
-		return is;
+		return false;
 	},
 
 	/**

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMCombos.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMCombos.js
@@ -1,23 +1,16 @@
 /**
  * DOM decoration time.
  * TODO: Standard DOM exceptions (at our level) for missing arguments and so on.
- * TODO: insertAdjecantHTML
  * TODO: DOM4 methods
- * TODO: Maintain some kind of gui.Guide.detachSub !!!!!!
- * @using {gui.Combo.before} before
+ * @using {gui.Combo.before} beforeype
  * @using {gui.Combo.after} after
  * @using {gui.Combo.around} around
  * @using {gui.Combo.provided} provided
+ * @using {gui.Type} Type
+ * @using {gui.Array} Array
+ * @using {gui.DOMPlugin} DOMPlugin
  */
-gui.DOMCombos = (function using(
-	before,
-	after,
-	around,
-	provided,
-	Type,
-	guiArray,
-	DOMPlugin
-) {
+gui.DOMCombos = (function using(before, after, around, provided, Type, guiArray, DOMPlugin) {
 	/**
 	 * Is `this` embedded in document? If `this` is a document
 	 * fragment, we'll look at those other arguments instead.
@@ -78,6 +71,14 @@ gui.DOMCombos = (function using(
 	 */
 	var detachBefore = before(function(node) {
 		detach(node || this);
+	});
+
+	/**
+	 * Detach subtree (only).
+	 */
+	var detachSubBefore = before(function() {
+		var childrenonly = true;
+		gui.Guide.$detach(this, childrenonly);
 	});
 
 	/**
@@ -166,7 +167,7 @@ gui.DOMCombos = (function using(
 	 *		 afterend: After the element itself
 	 * @param {string} html
 	 */
-	var spiritualizeAdjecantAfter = after(function(position, html) {
+	var spiritualizeAdjacentAfter = after(function(position, html) {
 		switch (position) {
 			case 'beforebegin':
 				console.warn('TODO: Spiritualize previous siblings');
@@ -184,16 +185,11 @@ gui.DOMCombos = (function using(
 	});
 
 	/**
-	 * Pretend nothing happened when running in managed mode.
-	 * TODO: Simply mirror this prop with an internal boolean
+	 * Abstract HTMLDocument might adopt DOM combos :/
+	 * @returns {boolean}
 	 */
 	var ifEnabled = provided(function() {
-		var win = this.ownerDocument.defaultView;
-		if (win) {
-			return win.gui.mode !== gui.MODE_HUMAN;
-		} else {
-			return false; // abstract HTMLDocument might adopt DOM combos
-		}
+		return !!(this.ownerDocument.defaultView);
 	});
 
 	/**
@@ -237,10 +233,10 @@ gui.DOMCombos = (function using(
 				otherwise(base))
 			);
 		},
-		insertAdjecantHTML: function(base) {
+		insertAdjacentHTML: function(base) {
 			return (
 				ifEnabled(
-					ifEmbedded(spiritualizeAdjecantAfter(suspending(base))),
+					ifEmbedded(spiritualizeAdjacentAfter(suspending(base))),
 					otherwise(base)),
 				otherwise(base)
 			);
@@ -284,7 +280,7 @@ gui.DOMCombos = (function using(
 		innerHTML: function(base) {
 			return (
 				ifEnabled(
-					ifEmbedded(detachBefore(spiritualizeSubAfter(suspending(base))),
+					ifEmbedded(detachSubBefore(spiritualizeSubAfter(suspending(base))),
 					otherwise(base)),
 				otherwise(base))
 			);
@@ -300,7 +296,7 @@ gui.DOMCombos = (function using(
 		textContent: function(base) {
 			return (
 				ifEnabled(
-					ifEmbedded(detachBefore(suspending(base)),
+					ifEmbedded(detachSubBefore(suspending(base)),
 					otherwise(base)),
 				otherwise(base))
 			);


### PR DESCRIPTION
@wiredearp @zdlm @sampi

I had no luck with the tests in Edge today (and eventually it stopped working altogether, reporting syntax errors in unedited files like `Jasmine.js`), so I marveled for a moment on yesterdays success and spotted an error: We should only `detach()` the children of an element when handling `innerHTML` and `textContent`, but we were triggering `detach()` on the element itself. Also spotted a typo in method name `insertAdjacentHTML` (which by the way we don't support, but at least we will now get console messages, so we can hurry up and fix it, in case React or Angular or jQuery is using that stuff).
