### PR TITLE
Fix master + actually support Edge

### DIFF
--- a/browserstack.json
+++ b/browserstack.json
@@ -5,6 +5,7 @@
 		"chrome_latest",
 		"firefox_latest",
 		"safari_latest",
+		"edge_latest",
 		"chrome_previous",
 		"firefox_previous",
 		"safari_previous",

--- a/spec/jasmine/index.html
+++ b/spec/jasmine/index.html
@@ -11,7 +11,6 @@
 		<script src="jasmine-2.4.1/jasmine-html.js"></script>
 		<script src="jasmine-2.4.1/boot.js"></script>
 		<script src="jasmine-2.4.1/boot.js"></script>
-		<script src="helpers.js"></script>
 	</head>
 	<body>
 		<main data-ts="Main"></main>

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMChanger.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMChanger.js
@@ -112,7 +112,6 @@ gui.DOMChanger = {
 		if (this._ismethod(name)) {
 			this._domethod(proto, name, combo);
 		} else {
-			this._doaccessor(proto, name, combo);
 			if (gui.Client.isGecko) {
 				this._dogeckoaccesor(proto, name, combo, root);
 			} else if (ok) {

--- a/src/spiritual/spiritual-gui/gui@wunderbyte.com/utils/gui.Client.js
+++ b/src/spiritual/spiritual-gui/gui@wunderbyte.com/utils/gui.Client.js
@@ -221,7 +221,7 @@ gui.Client = (function() {
 		 * @type {boolean}
 		 */
 		this.hasAttributesOnPrototype = (function(Client_) {
-			if (Client_.isSafari) {
+			if (Client_.isSafari || Client_.isEdge) {
 				return false;
 			} else if (Client_.isWebKit) {
 				var rex = /chrom(e|ium)\/([0-9]+)\./;

--- a/src/spiritual/spiritual-mix/gui-layout@wunderbyte.com/plugins/visibility.plugin/gui.VisibilityPlugin.js
+++ b/src/spiritual/spiritual-mix/gui-layout@wunderbyte.com/plugins/visibility.plugin/gui.VisibilityPlugin.js
@@ -72,7 +72,9 @@ gui.VisibilityPlugin = (function using(chained) {
 		 * @param {gui.Spirit} spirit
 		 */
 		$init: function(spirit) {
-			this._go(spirit, !this._invisible(spirit));
+			if (!spirit.$destructed) {
+				this._go(spirit, !this._invisible(spirit));
+			}
 		},
 
 		// Private static ..........................................................


### PR DESCRIPTION
@wiredearp @zdlm @sampi

An earlier attempt to cleanup some business logic was aborted, but not fully reverted to the initial state. As a consequence, the DOM overrides for fancy browsers would be applied to the current version of Safari, which is not so fancy. This bad code made it all the way to `master` even while breaking the tests. I still don't know why Travis would report the tests as passed, when in reality they failed us completely.

:tada: The good news is that the tests are now also passing in Edge. The bad news is that we have not really been supporting Edge up until now, because we have been expecting a fancy browser where in reality it must be instructed to handle `innerHTML`, `outerHTML` and `textContent` in the same hacky way as Safari (via MutationObserver). Surprising because the overrides would fail silently; and double surprising because the fancy method has been working out for Microsoft since IE9. I guess this whole time we were just lucky that Angular and React don't use much `innerHTML` (because in modern browsers that is now slower than `appendChild` and friends).