### PR TITLE
[Forms] Only spiritualize the first `<input />` after a `<span />` inside…

### DIFF
--- a/docs/dist/appendix/autofocus/index.html
+++ b/docs/dist/appendix/autofocus/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Automagic Focus</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/autofocus/index.html
+++ b/docs/dist/appendix/autofocus/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Automagic Focus</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/autolayout/index.html
+++ b/docs/dist/appendix/autolayout/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Automated Layout</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/autolayout/index.html
+++ b/docs/dist/appendix/autolayout/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Automated Layout</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/colors/index.html
+++ b/docs/dist/appendix/colors/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Colors</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/colors/index.html
+++ b/docs/dist/appendix/colors/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Colors</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/index.html
+++ b/docs/dist/appendix/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Appendix</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/index.html
+++ b/docs/dist/appendix/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Appendix</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/markdown/index.html
+++ b/docs/dist/appendix/markdown/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Markdown</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/markdown/index.html
+++ b/docs/dist/appendix/markdown/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Markdown</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/responsive/index.html
+++ b/docs/dist/appendix/responsive/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Responsive Design</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/responsive/index.html
+++ b/docs/dist/appendix/responsive/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Responsive Design</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/typo/index.html
+++ b/docs/dist/appendix/typo/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Typography</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/appendix/typo/index.html
+++ b/docs/dist/appendix/typo/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Typography</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/api-only.html
+++ b/docs/dist/components/api-only.html
@@ -4,7 +4,7 @@
 <head>
     <title>API-only Components</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/api-only.html
+++ b/docs/dist/components/api-only.html
@@ -4,7 +4,7 @@
 <head>
     <title>API-only Components</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/asides/index.html
+++ b/docs/dist/components/asides/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Aside HTML</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/asides/index.html
+++ b/docs/dist/components/asides/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Aside HTML</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/asides/js.html
+++ b/docs/dist/components/asides/js.html
@@ -4,7 +4,7 @@
 <head>
     <title>Aside JS</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/asides/js.html
+++ b/docs/dist/components/asides/js.html
@@ -4,7 +4,7 @@
 <head>
     <title>Aside JS</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/asides/test-1.html
+++ b/docs/dist/components/asides/test-1.html
@@ -4,7 +4,7 @@
 <head>
     <title>Aside Test One</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/asides/test-1.html
+++ b/docs/dist/components/asides/test-1.html
@@ -4,7 +4,7 @@
 <head>
     <title>Aside Test One</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/bars/statusbar.html
+++ b/docs/dist/components/bars/statusbar.html
@@ -4,7 +4,7 @@
 <head>
     <title>StatusBar</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/bars/statusbar.html
+++ b/docs/dist/components/bars/statusbar.html
@@ -4,7 +4,7 @@
 <head>
     <title>StatusBar</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/bars/tabbar.html
+++ b/docs/dist/components/bars/tabbar.html
@@ -4,7 +4,7 @@
 <head>
     <title>TabBar</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/bars/tabbar.html
+++ b/docs/dist/components/bars/tabbar.html
@@ -4,7 +4,7 @@
 <head>
     <title>TabBar</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/bars/toolbar.html
+++ b/docs/dist/components/bars/toolbar.html
@@ -4,7 +4,7 @@
 <head>
     <title>ToolBar</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/bars/toolbar.html
+++ b/docs/dist/components/bars/toolbar.html
@@ -4,7 +4,7 @@
 <head>
     <title>ToolBar</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/bars/topbar.html
+++ b/docs/dist/components/bars/topbar.html
@@ -4,7 +4,7 @@
 <head>
     <title>TopBar</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/bars/topbar.html
+++ b/docs/dist/components/bars/topbar.html
@@ -4,7 +4,7 @@
 <head>
     <title>TopBar</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/buttons/buttons.html
+++ b/docs/dist/components/buttons/buttons.html
@@ -4,7 +4,7 @@
 <head>
     <title>Buttons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/buttons/buttons.html
+++ b/docs/dist/components/buttons/buttons.html
@@ -4,7 +4,7 @@
 <head>
     <title>Buttons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/buttons/gallery.html
+++ b/docs/dist/components/buttons/gallery.html
@@ -4,7 +4,7 @@
 <head>
     <title>Button Gallery</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/buttons/gallery.html
+++ b/docs/dist/components/buttons/gallery.html
@@ -4,7 +4,7 @@
 <head>
     <title>Button Gallery</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/buttons/index.html
+++ b/docs/dist/components/buttons/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Button</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/buttons/index.html
+++ b/docs/dist/components/buttons/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Button</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/cards/companycard.html
+++ b/docs/dist/components/cards/companycard.html
@@ -4,7 +4,7 @@
 <head>
     <title>CompanyCard</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/cards/companycard.html
+++ b/docs/dist/components/cards/companycard.html
@@ -4,7 +4,7 @@
 <head>
     <title>CompanyCard</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/cards/extras.html
+++ b/docs/dist/components/cards/extras.html
@@ -4,7 +4,7 @@
 <head>
     <title>CompanyCard extras</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/cards/extras.html
+++ b/docs/dist/components/cards/extras.html
@@ -4,7 +4,7 @@
 <head>
     <title>CompanyCard extras</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/cards/usercard.html
+++ b/docs/dist/components/cards/usercard.html
@@ -4,7 +4,7 @@
 <head>
     <title>UserCard</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/cards/usercard.html
+++ b/docs/dist/components/cards/usercard.html
@@ -4,7 +4,7 @@
 <head>
     <title>UserCard</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/datepicker/index.html
+++ b/docs/dist/components/datepicker/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>DatePicker</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/datepicker/index.html
+++ b/docs/dist/components/datepicker/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>DatePicker</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/dialogs/index.html
+++ b/docs/dist/components/dialogs/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Dialog</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/dialogs/index.html
+++ b/docs/dist/components/dialogs/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Dialog</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/autocomplete.html
+++ b/docs/dist/components/forms/autocomplete.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form Autocomplete</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/autocomplete.html
+++ b/docs/dist/components/forms/autocomplete.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form Autocomplete</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/disabled.html
+++ b/docs/dist/components/forms/disabled.html
@@ -4,7 +4,7 @@
 <head>
     <title>Disabled &amp; Readonly Fields</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/disabled.html
+++ b/docs/dist/components/forms/disabled.html
@@ -4,7 +4,7 @@
 <head>
     <title>Disabled &amp; Readonly Fields</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/example.html
+++ b/docs/dist/components/forms/example.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form Example</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/example.html
+++ b/docs/dist/components/forms/example.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form Example</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/index.html
+++ b/docs/dist/components/forms/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/index.html
+++ b/docs/dist/components/forms/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/redesign.html
+++ b/docs/dist/components/forms/redesign.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form Example</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/redesign.html
+++ b/docs/dist/components/forms/redesign.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form Example</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/test-1.html
+++ b/docs/dist/components/forms/test-1.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form Test</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/forms/test-1.html
+++ b/docs/dist/components/forms/test-1.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form Test</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/icons/css.html
+++ b/docs/dist/components/icons/css.html
@@ -4,7 +4,7 @@
 <head>
     <title>Icons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/icons/css.html
+++ b/docs/dist/components/icons/css.html
@@ -4,7 +4,7 @@
 <head>
     <title>Icons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/icons/iconspirit.html
+++ b/docs/dist/components/icons/iconspirit.html
@@ -4,7 +4,7 @@
 <head>
     <title>Icons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/icons/iconspirit.html
+++ b/docs/dist/components/icons/iconspirit.html
@@ -4,7 +4,7 @@
 <head>
     <title>Icons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/icons/index.html
+++ b/docs/dist/components/icons/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Icons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/icons/index.html
+++ b/docs/dist/components/icons/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Icons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/icons/list.html
+++ b/docs/dist/components/icons/list.html
@@ -4,7 +4,7 @@
 <head>
     <title>Icons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/icons/list.html
+++ b/docs/dist/components/icons/list.html
@@ -4,7 +4,7 @@
 <head>
     <title>Icons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/index.html
+++ b/docs/dist/components/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Inline Components</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/index.html
+++ b/docs/dist/components/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Inline Components</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/menus/index.html
+++ b/docs/dist/components/menus/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Menu</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/menus/index.html
+++ b/docs/dist/components/menus/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Menu</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/modals/index.html
+++ b/docs/dist/components/modals/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Modal</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/modals/index.html
+++ b/docs/dist/components/modals/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Modal</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/notes/index.html
+++ b/docs/dist/components/notes/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Note</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/notes/index.html
+++ b/docs/dist/components/notes/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Note</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/notifications/index.html
+++ b/docs/dist/components/notifications/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Notification</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/notifications/index.html
+++ b/docs/dist/components/notifications/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Notification</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/pager/index.html
+++ b/docs/dist/components/pager/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Pager</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/pager/index.html
+++ b/docs/dist/components/pager/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Pager</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/panels/index.html
+++ b/docs/dist/components/panels/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Panels</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/panels/index.html
+++ b/docs/dist/components/panels/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Panels</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/search/index.html
+++ b/docs/dist/components/search/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Search</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/search/index.html
+++ b/docs/dist/components/search/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Search</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/sidebars/index.html
+++ b/docs/dist/components/sidebars/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>SideBars</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/sidebars/index.html
+++ b/docs/dist/components/sidebars/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>SideBars</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/sidebars/test-1.html
+++ b/docs/dist/components/sidebars/test-1.html
@@ -4,7 +4,7 @@
 <head>
     <title>SideBars Test One</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/sidebars/test-1.html
+++ b/docs/dist/components/sidebars/test-1.html
@@ -4,7 +4,7 @@
 <head>
     <title>SideBars Test One</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/spinners/index.html
+++ b/docs/dist/components/spinners/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Spinner</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/spinners/index.html
+++ b/docs/dist/components/spinners/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Spinner</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/angular.html
+++ b/docs/dist/components/table/angular.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Demo</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/angular.html
+++ b/docs/dist/components/table/angular.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Demo</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/building.html
+++ b/docs/dist/components/table/building.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Build</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/building.html
+++ b/docs/dist/components/table/building.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Build</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/clicking.html
+++ b/docs/dist/components/table/clicking.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Click</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/clicking.html
+++ b/docs/dist/components/table/clicking.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Click</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/configuring.html
+++ b/docs/dist/components/table/configuring.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Config</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/configuring.html
+++ b/docs/dist/components/table/configuring.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Config</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/demo.html
+++ b/docs/dist/components/table/demo.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Demo</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/demo.html
+++ b/docs/dist/components/table/demo.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Demo</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/editing.html
+++ b/docs/dist/components/table/editing.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Edit</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/editing.html
+++ b/docs/dist/components/table/editing.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Edit</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/extras.html
+++ b/docs/dist/components/table/extras.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Extras</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/extras.html
+++ b/docs/dist/components/table/extras.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Extras</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/filtering.html
+++ b/docs/dist/components/table/filtering.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Filter</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/filtering.html
+++ b/docs/dist/components/table/filtering.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Filter</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/formatting.html
+++ b/docs/dist/components/table/formatting.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Formatting</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/formatting.html
+++ b/docs/dist/components/table/formatting.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Formatting</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/gutter.html
+++ b/docs/dist/components/table/gutter.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Floating Gutter</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/gutter.html
+++ b/docs/dist/components/table/gutter.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Floating Gutter</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/index.html
+++ b/docs/dist/components/table/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/index.html
+++ b/docs/dist/components/table/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/layouting.html
+++ b/docs/dist/components/table/layouting.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Layout</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/layouting.html
+++ b/docs/dist/components/table/layouting.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Layout</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/paging.html
+++ b/docs/dist/components/table/paging.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Paging</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/paging.html
+++ b/docs/dist/components/table/paging.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Paging</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/searching.html
+++ b/docs/dist/components/table/searching.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Search</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/searching.html
+++ b/docs/dist/components/table/searching.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Search</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/selecting.html
+++ b/docs/dist/components/table/selecting.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Select</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/selecting.html
+++ b/docs/dist/components/table/selecting.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Select</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/sorting.html
+++ b/docs/dist/components/table/sorting.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Sort</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/sorting.html
+++ b/docs/dist/components/table/sorting.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Sort</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/status.html
+++ b/docs/dist/components/table/status.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Sort</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/status.html
+++ b/docs/dist/components/table/status.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Sort</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/styling.html
+++ b/docs/dist/components/table/styling.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Styling</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/table/styling.html
+++ b/docs/dist/components/table/styling.html
@@ -4,7 +4,7 @@
 <head>
     <title>Table Styling</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/times/index.html
+++ b/docs/dist/components/times/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Time</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/times/index.html
+++ b/docs/dist/components/times/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Time</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/userimages/index.html
+++ b/docs/dist/components/userimages/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>UserImage</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/components/userimages/index.html
+++ b/docs/dist/components/userimages/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>UserImage</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/buttons.html
+++ b/docs/dist/design/copy/buttons.html
@@ -4,7 +4,7 @@
 <head>
     <title>Buttons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/buttons.html
+++ b/docs/dist/design/copy/buttons.html
@@ -4,7 +4,7 @@
 <head>
     <title>Buttons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/dev.html
+++ b/docs/dist/design/copy/dev.html
@@ -4,7 +4,7 @@
 <head>
     <title>Copy in the Development Process</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/dev.html
+++ b/docs/dist/design/copy/dev.html
@@ -4,7 +4,7 @@
 <head>
     <title>Copy in the Development Process</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/emails.html
+++ b/docs/dist/design/copy/emails.html
@@ -4,7 +4,7 @@
 <head>
     <title>Emails</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/emails.html
+++ b/docs/dist/design/copy/emails.html
@@ -4,7 +4,7 @@
 <head>
     <title>Emails</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/errors.html
+++ b/docs/dist/design/copy/errors.html
@@ -4,7 +4,7 @@
 <head>
     <title>Error Messages</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/errors.html
+++ b/docs/dist/design/copy/errors.html
@@ -4,7 +4,7 @@
 <head>
     <title>Error Messages</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/index.html
+++ b/docs/dist/design/copy/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>UI Copy Principles</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/index.html
+++ b/docs/dist/design/copy/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>UI Copy Principles</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/pickers.html
+++ b/docs/dist/design/copy/pickers.html
@@ -4,7 +4,7 @@
 <head>
     <title>Menu Pickers</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/pickers.html
+++ b/docs/dist/design/copy/pickers.html
@@ -4,7 +4,7 @@
 <head>
     <title>Menu Pickers</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/terms.html
+++ b/docs/dist/design/copy/terms.html
@@ -4,7 +4,7 @@
 <head>
     <title>Terminology &amp; Cheat Sheet</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/copy/terms.html
+++ b/docs/dist/design/copy/terms.html
@@ -4,7 +4,7 @@
 <head>
     <title>Terminology &amp; Cheat Sheet</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/index.html
+++ b/docs/dist/design/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Design Principles</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/index.html
+++ b/docs/dist/design/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Design Principles</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/buttons.html
+++ b/docs/dist/design/patterns/buttons.html
@@ -4,7 +4,7 @@
 <head>
     <title>Buttons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/buttons.html
+++ b/docs/dist/design/patterns/buttons.html
@@ -4,7 +4,7 @@
 <head>
     <title>Buttons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/emails.html
+++ b/docs/dist/design/patterns/emails.html
@@ -4,7 +4,7 @@
 <head>
     <title>Emails</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/emails.html
+++ b/docs/dist/design/patterns/emails.html
@@ -4,7 +4,7 @@
 <head>
     <title>Emails</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/fullpage.html
+++ b/docs/dist/design/patterns/fullpage.html
@@ -4,7 +4,7 @@
 <head>
     <title>Full page apps</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/fullpage.html
+++ b/docs/dist/design/patterns/fullpage.html
@@ -4,7 +4,7 @@
 <head>
     <title>Full page apps</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/index.html
+++ b/docs/dist/design/patterns/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Structure</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/index.html
+++ b/docs/dist/design/patterns/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Structure</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/nav.html
+++ b/docs/dist/design/patterns/nav.html
@@ -4,7 +4,7 @@
 <head>
     <title>Navigation Items</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/nav.html
+++ b/docs/dist/design/patterns/nav.html
@@ -4,7 +4,7 @@
 <head>
     <title>Navigation Items</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/pickers.html
+++ b/docs/dist/design/patterns/pickers.html
@@ -4,7 +4,7 @@
 <head>
     <title>Option Lists and Pickers</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/pickers.html
+++ b/docs/dist/design/patterns/pickers.html
@@ -4,7 +4,7 @@
 <head>
     <title>Option Lists and Pickers</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/switches.html
+++ b/docs/dist/design/patterns/switches.html
@@ -4,7 +4,7 @@
 <head>
     <title>Switches</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/switches.html
+++ b/docs/dist/design/patterns/switches.html
@@ -4,7 +4,7 @@
 <head>
     <title>Switches</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/tables.html
+++ b/docs/dist/design/patterns/tables.html
@@ -4,7 +4,7 @@
 <head>
     <title>Tables</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/design/patterns/tables.html
+++ b/docs/dist/design/patterns/tables.html
@@ -4,7 +4,7 @@
 <head>
     <title>Tables</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/development/rootpanels/index.html
+++ b/docs/dist/development/rootpanels/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Root Panels</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/development/rootpanels/index.html
+++ b/docs/dist/development/rootpanels/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Root Panels</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/getstarted/index.html
+++ b/docs/dist/getstarted/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Get Started</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/getstarted/index.html
+++ b/docs/dist/getstarted/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Get Started</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/getstarted/layout/index.html
+++ b/docs/dist/getstarted/layout/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Layout</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/getstarted/layout/index.html
+++ b/docs/dist/getstarted/layout/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Layout</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/getstarted/rules/index.html
+++ b/docs/dist/getstarted/rules/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Basic rules</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/getstarted/rules/index.html
+++ b/docs/dist/getstarted/rules/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Basic rules</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/getstarted/usage/index.html
+++ b/docs/dist/getstarted/usage/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Usage</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/getstarted/usage/index.html
+++ b/docs/dist/getstarted/usage/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Usage</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/index.html
+++ b/docs/dist/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Tradeshift UI</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/index.html
+++ b/docs/dist/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Tradeshift UI</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/intro/index.html
+++ b/docs/dist/intro/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Tradeshift UI</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/intro/index.html
+++ b/docs/dist/intro/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Tradeshift UI</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/index.html
+++ b/docs/dist/screenshots/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Screenshots</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/index.html
+++ b/docs/dist/screenshots/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Screenshots</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/asides.html
+++ b/docs/dist/screenshots/pages/asides.html
@@ -4,7 +4,7 @@
 <head>
     <title>Aside</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/asides.html
+++ b/docs/dist/screenshots/pages/asides.html
@@ -4,7 +4,7 @@
 <head>
     <title>Aside</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/bars.html
+++ b/docs/dist/screenshots/pages/bars.html
@@ -4,7 +4,7 @@
 <head>
     <title>Bars</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/bars.html
+++ b/docs/dist/screenshots/pages/bars.html
@@ -4,7 +4,7 @@
 <head>
     <title>Bars</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/buttons.html
+++ b/docs/dist/screenshots/pages/buttons.html
@@ -4,7 +4,7 @@
 <head>
     <title>Buttons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/buttons.html
+++ b/docs/dist/screenshots/pages/buttons.html
@@ -4,7 +4,7 @@
 <head>
     <title>Buttons</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/forms.html
+++ b/docs/dist/screenshots/pages/forms.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/forms.html
+++ b/docs/dist/screenshots/pages/forms.html
@@ -4,7 +4,7 @@
 <head>
     <title>Form</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/index.html
+++ b/docs/dist/screenshots/pages/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Screenshot Pages</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/index.html
+++ b/docs/dist/screenshots/pages/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Screenshot Pages</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/panels.html
+++ b/docs/dist/screenshots/pages/panels.html
@@ -4,7 +4,7 @@
 <head>
     <title>Screenshots</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/screenshots/pages/panels.html
+++ b/docs/dist/screenshots/pages/panels.html
@@ -4,7 +4,7 @@
 <head>
     <title>Screenshots</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/search/index.html
+++ b/docs/dist/search/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Search</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/dist/search/index.html
+++ b/docs/dist/search/index.html
@@ -4,7 +4,7 @@
 <head>
     <title>Search</title>
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 		<title>Tradeshift UI</title>
 		<script src="/dist/assets/lunr.min.js"></script>
 		<meta name="viewport" content="width=device-width"/>
-		<script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.0.min.js"></script>
+		<script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
 		<script src="/dist/assets/dox.min.js"></script>
 		<script src="/dist/assets/mark.min.js"></script>
 		<script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 		<title>Tradeshift UI</title>
 		<script src="/dist/assets/lunr.min.js"></script>
 		<meta name="viewport" content="width=device-width"/>
-		<script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.0.1-alpha.2.min.js"></script>
+		<script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-7.1.0.min.js"></script>
 		<script src="/dist/assets/dox.min.js"></script>
 		<script src="/dist/assets/mark.min.js"></script>
 		<script src="/dist/assets/jquery-2.2.4.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "lint": "./node_modules/.bin/eslint --fix --config ./.eslintrc.json .",
-    "test": "npm run lint && ./node_modules/.bin/grunt jasmine && ./node_modules/.bin/browserstack-runner",
+    "test": "npm run lint && ./node_modules/.bin/grunt jasmine && echo 'Running tests on https://www.browserstack.com/automate' && ./node_modules/.bin/browserstack-runner",
     "http": "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}'",
     "deploy-s3": "node tasks/deploy.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeshift-ui",
-  "version": "7.0.1-alpha.2",
+  "version": "7.1.0",
   "description": "The Tradeshift UI Library & Framework",
   "homepage": "https://ui.tradeshift.com/",
   "bugs": {

--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/module.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/module.js
@@ -53,6 +53,7 @@ ts.ui.FormsModule = gui.module('forms-gui@tradeshift.com', {
 				['.ts-form input[type=date]', ts.ui.DateInputSpirit],
 				['.ts-form span + input[type=checkbox]', ts.ui.SwitchSpirit],
 				['.ts-form input[type=checkbox], .ts-form input[type=radio]', ts.ui.OptionSpirit],
+				['.ts-form input + input', ts.ui.Spirit], // FakeElements in V4 ignored
 				['.ts-form input', ts.ui.TextInputSpirit],
 				['.ts-form textarea', ts.ui.TextAreaSpirit],
 				['.ts-form select', ts.ui.SelectSpirit]

--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.LabelSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.LabelSpirit.js
@@ -235,16 +235,7 @@ ts.ui.LabelSpirit = (function using(Client, FieldSpirit, chained, tick, time, co
 		 * @param {boolean} readonly
 		 */
 		$readonly: chained(function(readonly) {
-			/*
-			if (this.$isFakelabel()) { // fakelabel is always NOT readonly
-				this.css.remove(class_readonly);
-				return;
-			}
-			*/
-			var change = this.css.contains(class_readonly) ? !readonly : readonly;
-			if (change) {
-				this.css.shift(readonly, class_readonly);
-			}
+			this.css.shift(readonly, class_readonly);
 		}),
 
 		/**


### PR DESCRIPTION
… the `<label />`

We need to do this so that when there's a fake field as a sibling of a "real" field, both spirits are fighting for the `ts-readonly` and `ts-customiconlabel` classes causing the element to flash with attribute updates twice per second.

@wiredearp @zdlm @sampi

Fixes issue where the DevTools got really slow with a similar configuration:
```html
<form data-ts="Form">
	<fieldset>
		<label>
			<span>Text with custom icon</span>
			<input type="text" value="Text" readonly data-ts.icon="ts-icon-dispute" />
			<input type="text" value="Text" style="display: none;"/>
		</label>
	</fieldset>
</form>
```
