### PR TITLE
[Hooks] Add `pre-commit` hook on `npm install` automatically

### DIFF
--- a/.github/pre-commit
+++ b/.github/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# Generate GitHub Pages ready documentation files
+grunt dist
+# Stage them all!
+git add -A docs/index.html && git add -A docs/dist/*

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": "6.10.0"
   },
   "scripts": {
-    "postinstall": "cd docs && npm install",
+    "postinstall": "cp ./.github/pre-commit ./.git/hooks/pre-commit && cd docs && npm install",
     "lint": "./node_modules/.bin/eslint --fix --config ./.eslintrc.json .",
     "test": "npm run lint && ./node_modules/.bin/grunt jasmine && echo 'Running tests on https://www.browserstack.com/automate' && ./node_modules/.bin/browserstack-runner",
     "http": "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}'",


### PR DESCRIPTION
@wiredearp @zdlm @sampi

Fixes issue where the hooks aren't installed for new clones of the repo.
