### PR TITLE
DoorManPlugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -373,7 +373,7 @@ module.exports = function(grunt) {
 		// repeat these steps when needed
 		watch: {
 			js: {
-				tasks: ['concurrent:dev_generate_js'].concat(concatAndUglifyJs('dev')),
+				tasks: [].concat[('concurrent:dev_generate_js', concatAndUglifyJs('dev'))],
 				files: ['src/**/*.js', 'src/**/*.json']
 			},
 			less: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -373,7 +373,7 @@ module.exports = function(grunt) {
 		// repeat these steps when needed
 		watch: {
 			js: {
-				tasks: concatAndUglifyJs('dev'),
+				tasks: ['concurrent:dev_generate_js'].concat(concatAndUglifyJs('dev')),
 				files: ['src/**/*.js', 'src/**/*.json']
 			},
 			less: {

--- a/docs/dist/components/modals/index.html
+++ b/docs/dist/components/modals/index.html
@@ -297,6 +297,65 @@
                     <p>If you expect the server to respond particularly slowly today, you can also use the equivalent methods <code>spin()</code> and <code>stop()</code> to <a onclick="spinner()">display a spinner</a> while loading.</p>
                 </section>
                 <section>
+                    <h3><span>Tracking the state</span></h3>
+                    <p>You can implement the methods <code>onopen</code>, <code>onopened</code>, <code>onclose</code> and <code>onclosed</code> to do something whenever the Modal changes state.
+                        <figure data-ts="DoxScript" data-ts.code="ts.ui.get(myelement%2C%20function(modal)%20%7B%0A%09Object.assign(modal%2C%20%7B%0A%09%09onopen%3A%20function()%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20console.log(&apos;Will%20open&apos;)%3B%0A%20%20%20%20%20%20%20%20%7D%2C%0A%09%09onopened%3A%20function()%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20console.log(&apos;Did%20open&apos;)%3B%0A%20%20%20%20%20%20%20%20%7D%2C%0A%09%09onclose%3A%20function()%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20console.log(&apos;Will%20close&apos;)%3B%0A%20%20%20%20%20%20%20%20%7D%2C%0A%09%09onclosed%3A%20function()%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20console.log(&apos;Did%20close&apos;)%3B%0A%20%20%20%20%20%20%20%20%7D%0A%09%7D)%3B%0A%7D)%3B">
+                            <input type="hidden" value="%7B%22show%22%3Afalse%2C%22outs%22%3Afalse%2C%22runs%22%3Afalse%2C%22flip%22%3Afalse%7D">
+                            <div class="tabpanels">
+                                <pre class="prism language-javascript">
+<code>ts<span class="token punctuation">.</span>ui<span class="token punctuation">.</span><span class="token keyword">get</span><span class="token punctuation">(</span>myelement<span class="token punctuation">,</span> modal <span class="token operator">=</span><span class="token operator">&gt;</span> <span class="token punctuation">{</span>
+	Object<span class="token punctuation">.</span><span class="token function">assign<span class="token punctuation">(</span></span>modal<span class="token punctuation">,</span> <span class="token punctuation">{</span>
+		onopen<span class="token punctuation">:</span> <span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token operator">=</span><span class="token operator">&gt;</span> console<span class="token punctuation">.</span><span class="token function">log<span class="token punctuation">(</span></span><span class="token string">&apos;Will open&apos;</span><span class="token punctuation">)</span><span class="token punctuation">,</span>
+		onopened<span class="token punctuation">:</span> <span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token operator">=</span><span class="token operator">&gt;</span> console<span class="token punctuation">.</span><span class="token function">log<span class="token punctuation">(</span></span><span class="token string">&apos;Did open&apos;</span><span class="token punctuation">)</span><span class="token punctuation">,</span>
+		onclose<span class="token punctuation">:</span> <span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token operator">=</span><span class="token operator">&gt;</span> console<span class="token punctuation">.</span><span class="token function">log<span class="token punctuation">(</span></span><span class="token string">&apos;Will close&apos;</span><span class="token punctuation">)</span><span class="token punctuation">,</span>
+		onclosed<span class="token punctuation">:</span> <span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token operator">=</span><span class="token operator">&gt;</span> console<span class="token punctuation">.</span><span class="token function">log<span class="token punctuation">(</span></span><span class="token string">&apos;Did close&apos;</span><span class="token punctuation">)</span>
+	<span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+<span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span></code>
+</pre>
+                            </div>
+                        </figure>
+                    </p>
+                    <p>If you return <code>false</code> in methods <code>onopen</code> and <code>onclose</code>, the Modal will respect that. You can also setup inline callbacks to be invoked when the Modal changes state.</p>
+                    <figure data-ts="DoxMarkup" data-ts.code="%3Cdialog%20data-ts%3D%22Modal%22%0A%09data-ts.onopen%3D%22console.log(&apos;Will%20open&apos;)%22%0A%09data-ts.onopened%3D%22console.log(&apos;Did%20open&apos;)%22%0A%09data-ts.onclose%3D%22console.log(&apos;Will%20close&apos;)%22%0A%09data-ts.onclosed%3D%22console.log(&apos;Did%20close&apos;)%22%3E%0A%09%3Cdiv%20data-ts%3D%22Panel%22%3E%0A%09%09%3Cp%3EModal%20content.%3C%2Fp%3E%0A%09%3C%2Fdiv%3E%0A%3C%2Fdialog%3E">
+                        <script type="text/html">
+                            <dialog data-ts="Modal" data-ts.onopen="console.log('Will open')" data-ts.onopened="console.log('Did open')" data-ts.onclose="console.log('Will close')" data-ts.onclosed="console.log('Did close')">
+                                <div data-ts="Panel">
+                                    <p>Modal content.</p>
+                                </div>
+                            </dialog>
+                        </script><input type="hidden" value="%7B%22show%22%3Afalse%2C%22outs%22%3Afalse%2C%22runs%22%3Afalse%2C%22flip%22%3Afalse%7D">
+                        <div class="tabpanels">
+                            <pre class="prism language-markup">
+<code><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>dialog</span> <span class="token attr-name">data-ts</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">&quot;</span>Modal<span class="token punctuation">&quot;</span></span>
+	<span class="token attr-name">data-ts</span>.<span class="token attr-name">onopen</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">&quot;</span>console.log(&apos;Will open&apos;)<span class="token punctuation">&quot;</span></span>
+	<span class="token attr-name">data-ts</span>.<span class="token attr-name">onopened</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">&quot;</span>console.log(&apos;Did open&apos;)<span class="token punctuation">&quot;</span></span>
+	<span class="token attr-name">data-ts</span>.<span class="token attr-name">onclose</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">&quot;</span>console.log(&apos;Will close&apos;)<span class="token punctuation">&quot;</span></span>
+	<span class="token attr-name">data-ts</span>.<span class="token attr-name">onclosed</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">&quot;</span>console.log(&apos;Did close&apos;)<span class="token punctuation">&quot;</span></span><span class="token punctuation">&gt;</span></span>
+	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>div</span> <span class="token attr-name">data-ts</span><span class="token attr-value"><span class="token punctuation">=</span><span class="token punctuation">&quot;</span>Panel<span class="token punctuation">&quot;</span></span><span class="token punctuation">&gt;</span></span>
+		<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>p</span><span class="token punctuation">&gt;</span></span>Modal content.<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>p</span><span class="token punctuation">&gt;</span></span>
+	<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>div</span><span class="token punctuation">&gt;</span></span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>dialog</span><span class="token punctuation">&gt;</span></span></code>
+</pre>
+                        </div>
+                    </figure>
+                    <p>Finally, you can also track the state with some custom DOM events if you like.</p>
+                    <figure data-ts="DoxScript" data-ts.code="function%20debug(e)%20%7B%0A%09console.log(e.type%2C%20e.target)%3B%0A%7D%0Adocument.addEventListener(&apos;ts-open&apos;%2C%20debug)%3B%0Adocument.addEventListener(&apos;ts-opened&apos;%2C%20debug)%3B%0Adocument.addEventListener(&apos;ts-close&apos;%2C%20debug)%3B%0Adocument.addEventListener(&apos;ts-closed&apos;%2C%20debug)%3B">
+                        <input type="hidden" value="%7B%22show%22%3Afalse%2C%22outs%22%3Afalse%2C%22runs%22%3Afalse%2C%22flip%22%3Afalse%7D">
+                        <div class="tabpanels">
+                            <pre class="prism language-javascript">
+<code><span class="token keyword">function</span> <span class="token function">debug<span class="token punctuation">(</span></span>e<span class="token punctuation">)</span> <span class="token punctuation">{</span>
+	console<span class="token punctuation">.</span><span class="token function">log<span class="token punctuation">(</span></span>e<span class="token punctuation">.</span>type<span class="token punctuation">,</span> e<span class="token punctuation">.</span>target<span class="token punctuation">)</span><span class="token punctuation">;</span>
+<span class="token punctuation">}</span>
+document<span class="token punctuation">.</span><span class="token function">addEventListener<span class="token punctuation">(</span></span><span class="token string">&apos;ts-open&apos;</span><span class="token punctuation">,</span> debug<span class="token punctuation">)</span><span class="token punctuation">;</span>
+document<span class="token punctuation">.</span><span class="token function">addEventListener<span class="token punctuation">(</span></span><span class="token string">&apos;ts-opened&apos;</span><span class="token punctuation">,</span> debug<span class="token punctuation">)</span><span class="token punctuation">;</span>
+document<span class="token punctuation">.</span><span class="token function">addEventListener<span class="token punctuation">(</span></span><span class="token string">&apos;ts-close&apos;</span><span class="token punctuation">,</span> debug<span class="token punctuation">)</span><span class="token punctuation">;</span>
+document<span class="token punctuation">.</span><span class="token function">addEventListener<span class="token punctuation">(</span></span><span class="token string">&apos;ts-closed&apos;</span><span class="token punctuation">,</span> debug<span class="token punctuation">)</span><span class="token punctuation">;</span></code>
+</pre>
+                        </div>
+                    </figure>
+                    <p>The events <code>ts-open</code> and <code>ts-close</code> can be blocked with <code>e.preventDefault()</code> to prevent the Modal from changing state.</p>
+                </section>
+                <section>
                     <p>Here&apos;s finally an overview of the Modal API.</p>
                     <div data-ts="DoxApi" data-ts.code="%7B%0A%09name%3A%20%22ts.ui.ModalSpirit%22%2C%0A%09methods%3A%20%5B%0A%09%09%7B%0A%09%09%09name%3A%20%22tabs%22%2C%0A%09%09%09args%3A%20%22(array)%22%2C%0A%09%09%09desc%3A%20%22Get%20or%20set%20the%20tabs.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22buttons%22%2C%0A%09%09%09args%3A%20%22(array)%22%2C%0A%09%09%09desc%3A%20%22Get%20or%20set%20the%20buttons.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22title%22%2C%0A%09%09%09args%3A%20%22(array)%22%2C%0A%09%09%09desc%3A%20%22Get%20or%20set%20the%20title.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22open%22%2C%0A%09%09%09desc%3A%20%22Open%20the%20Modal.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22close%22%2C%0A%09%09%09desc%3A%20%22Close%20the%20Modal.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22busy%22%2C%0A%09%09%09desc%3A%20%22Hide%20the%20content%20(while%20loading%20new%20content).%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22done%22%2C%0A%09%09%09desc%3A%20%22Show%20the%20content.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22spin%22%2C%0A%09%09%09desc%3A%20%22Hide%20the%20content%20while%20showing%20a%20spinner.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22stop%22%2C%0A%09%09%09desc%3A%20%22Stop%20that%20spinner%20and%20show%20the%20content.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22status%22%2C%0A%09%09%09args%3A%20%22string%22%2C%0A%09%09%09desc%3A%20%22Show%20a%20message%20in%20the%20StatusBar.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22pager%22%2C%0A%09%09%09args%3A%20%22object%22%2C%0A%09%09%09desc%3A%20%22Get%20or%20set%20the%20(Pager)%5B%2F%23components%2Fpager%2F%5D%20in%20the%20StatusBar.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22reflex%22%2C%0A%09%09%09desc%3A%20%22Run%20JS%20based%20layout%2C%20usually%20to%20center%20the%20%60Main%60%20vertically.%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22onopen%22%2C%0A%09%09%09desc%3A%20%22Called%20when%20the%20Modal%20is%20about%20to%20open%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22onopened%22%2C%0A%09%09%09desc%3A%20%22Called%20when%20the%20Modal%20is%20fully%20opened%20(animation%20done)%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22onclose%22%2C%0A%09%09%09desc%3A%20%22Called%20when%20the%20Modal%20is%20about%20to%20closed%22%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%22onclosed%22%2C%0A%09%09%09desc%3A%20%22Called%20when%20the%20Modal%20is%20fully%20closed%20(animation%20done)%22%0A%09%09%7D%0A%09%5D%0A%7D">
                         <div>
@@ -306,6 +365,7 @@
             </article>
         </div>
     </main>
+    <!-- Modals ............................................................. -->
     <dialog data-ts="Modal" id="example1" data-ts.title="Example Modal">
         <div data-ts="Panel">
             <main data-ts="Main">

--- a/docs/src/xhtml/components/modals/index.xhtml
+++ b/docs/src/xhtml/components/modals/index.xhtml
@@ -203,6 +203,52 @@
 					<p>If you expect the server to respond particularly slowly today, you can also use the equivalent methods <code>spin()</code> and <code>stop()</code> to <a onclick="spinner()">display a spinner</a> while loading.</p>
 				</section>
 
+				
+				<section>
+					<h3>Tracking the state</h3>
+					<p>You can implement the methods <code>onopen</code>, <code>onopened</code>, <code>onclose</code> and <code>onclosed</code> to do something whenever the Modal changes state.
+
+					<figure data-ts="DoxScript">
+						<script>
+							ts.ui.get(myelement, modal => {
+								Object.assign(modal, {
+									onopen: () => console.log('Will open'),
+									onopened: () => console.log('Did open'),
+									onclose: () => console.log('Will close'),
+									onclosed: () => console.log('Did close')
+								});
+							});
+						</script>
+					</figure>
+					<p>If you return <code>false</code> in methods <code>onopen</code> and <code>onclose</code>, the Modal will respect that. You can also setup inline callbacks to be invoked when the Modal changes state.</p>
+					<figure data-ts="DoxMarkup">
+						<script type="text/html">
+							<dialog data-ts="Modal"
+								data-ts.onopen="console.log('Will open')"
+								data-ts.onopened="console.log('Did open')"
+								data-ts.onclose="console.log('Will close')"
+								data-ts.onclosed="console.log('Did close')">
+								<div data-ts="Panel">
+									<p>Modal content.</p>
+								</div>
+							</dialog>
+						</script>
+					</figure>
+					<p>Finally, you can also track the state with some custom DOM events if you like.</p>
+					<figure data-ts="DoxScript">
+						<script>
+							function debug(e) {
+								console.log(e.type, e.target);
+							}
+							document.addEventListener('ts-open', debug);
+							document.addEventListener('ts-opened', debug);
+							document.addEventListener('ts-close', debug);
+							document.addEventListener('ts-closed', debug);
+						</script>
+					</figure>
+					<p>The events <code>ts-open</code> and <code>ts-close</code> can  be blocked with <code>e.preventDefault()</code> to prevent the Modal from changing state.</p>
+				</section>
+
 				<section>
 					<p>Here's finally an overview of the Modal API.</p>
 					<div data-ts="DoxApi">
@@ -286,6 +332,8 @@
 				</section>
 			</article>
 		</main>
+
+		<!-- Modals ............................................................. -->
 
 		<dialog data-ts="Modal" id="example1" data-ts.title="Example Modal">
 			<div data-ts="Panel">

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "http": "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}'",
     "****** NODE *****": "",
     "postinstall": "cd docs && yarn",
-    "precommit": "lint-staged & grunt exec:docs_dist & wait && git add -A docs/{index.html,dist/**/*}"
+    "precommit": "lint-staged & grunt exec:docs_dist",
+    "NOTWORKING": "wait && git add -A docs/{index.html,dist/**/*}"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "http": "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}'",
     "****** NODE *****": "",
     "postinstall": "cd docs && yarn",
-    "precommit": "lint-staged & grunt exec:docs_dist",
-    "NOTWORKING": "wait && git add -A docs/{index.html,dist/**/*}"
+    "precommit": "lint-staged && grunt exec:docs_dist",
+    "STILL_NOT_WORKING": "&& git add -A docs/{index.html,src/less/ts-runtime.less,dist/**/*}"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "http": "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}'",
     "****** NODE *****": "",
     "postinstall": "cd docs && yarn",
-    "precommit": "lint-staged && grunt exec:docs_dist",
-    "STILL_NOT_WORKING": "&& git add -A docs/{index.html,src/less/ts-runtime.less,dist/**/*}"
+    "precommit": "lint-staged && grunt exec:docs_dist && git add -A docs/{index.html,src/less/ts-runtime.less,dist/**/*}"
   },
   "lint-staged": {
     "*.js": [

--- a/spec/jasmine/helpers.js
+++ b/spec/jasmine/helpers.js
@@ -16,19 +16,16 @@ gui.debug = true;
 window.sometime = function(later, thisp) {
 	setTimeout(function() {
 		later.call(thisp);
-	}, gui.Client.isExplorer ? 500 : 250);
+	}, 500);
 };
 
 window.helper = {
-
 	/**
 	 * Create an element to conduct tests within.
 	 * @param @optional {constructor} Spirit Optionally append a spirit here
 	 */
 	createTestDom: function(Spirit) {
-		var main = document.body.appendChild(
-			document.createElement('main')
-		);
+		var main = document.body.appendChild(document.createElement('main'));
 		main.className = 'ts-main';
 		if (Spirit) {
 			var spirit = Spirit.summon();

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/build.json
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/build.json
@@ -7,6 +7,7 @@
 	"plugins/common/ts.ui.LayoutPlugin.js",
 	"plugins/common/ts.ui.AttentionPlugin.js",
 	"plugins/common/ts.ui.PanelsPlugin.js",
+	"plugins/common/ts.ui.DoorManPlugin.js",
 	"plugins/document/ts.ui.DocumentLayoutPlugin.js",
 	"plugins/document/ts.ui.DocumentDialogPlugin.js",
 	"plugins/document/ts.ui.DocumentAsidePlugin.js",

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/module.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/module.js
@@ -130,10 +130,12 @@ ts.ui.CoreModule = gui.module('core-gui@tradeshift.com', {
 	},
 
 	/**
-	 * Hm...
+	 * TODO: SideShowSpirit should also refactor to use the PanelsPlugin
 	 */
 	_specialplugins: function() {
 		ts.ui.ModalSpirit.plugin('panels', ts.ui.PanelsPlugin);
+		ts.ui.ModalSpirit.plugin('doorman', ts.ui.DoorManPlugin);
+		ts.ui.SideShowSpirit.plugin('doorman', ts.ui.DoorManPlugin);
 	},
 
 	/**

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/plugins/common/ts.ui.DoorManPlugin.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/plugins/common/ts.ui.DoorManPlugin.js
@@ -1,0 +1,153 @@
+/**
+ * The DoorManPlugin attempts to ensure a unified interface 
+ * for opening and closing Asides, SideBars and Modals.
+ * @extends {ts.ui.Plugin}
+ * @using {gui.Type}
+ */
+ts.ui.DoorManPlugin = (function(Type) {
+	// custom dom events (for public consumption)
+	// TODO: These are now used in SideBars and Modals and should be renamed
+	var domevent = {
+		WILLOPEN: ts.ui.EVENT_ASIDE_WILL_OPEN,
+		DIDOPEN: ts.ui.EVENT_ASIDE_DID_OPEN,
+		WILLCLOSE: ts.ui.EVENT_ASIDE_WILL_CLOSE,
+		DIDCLOSE: ts.ui.EVENT_ASIDE_DID_CLOSE
+	};
+
+	return ts.ui.Plugin.extend(
+		{
+			/**
+		 * TODO: Only in debug mode
+		 */
+			onconstruct: function() {
+				this.super.onconstruct();
+				var apis = 'isOpen onopen onopened onclose onclosed $onopen $onclose';
+				var host = this.spirit;
+				apis.split(' ').forEach(function(api) {
+					if (host[api] === undefined) {
+						throw new Error('Missing interface "' + api + '"');
+					}
+				});
+			},
+
+			/**
+		 * Open AND close the aside (setup to support HTML `data-ts.open="true|false"`)
+		 * @param @optional {boolean} opt_open Omit to simply open.
+		 * @returns {boolean} True if allowed to open
+		 */
+			open: function(opt_open) {
+				var spirit = this.spirit;
+				if (!Type.isBoolean(opt_open)) {
+					opt_open = true;
+				}
+				if (this._shouldattempt(opt_open)) {
+					if (opt_open) {
+						if (!spirit.isOpen) {
+							return this._maybeopen(spirit.life.async);
+						}
+					} else {
+						if (spirit.isOpen) {
+							return this._maybeclose(spirit.life.async);
+						}
+					}
+				}
+				return false;
+			},
+
+			/**
+		 *
+		 */
+			didopen: function() {
+				this._execute('onopened');
+				this.spirit.event.dispatch(domevent.DIDCLOSE, {
+					bubbles: true
+				});
+			},
+
+			/**
+		 *
+		 */
+			didclose: function() {
+				this._execute('onclosed');
+				this.spirit.event.dispatch(domevent.DIDOPEN, {
+					bubbles: true
+				});
+			},
+
+			// Private .................................................................
+
+			/**
+		 * Fire custom DOM event and return whether or not this was preventDefaulted.
+		 * @param {boolean} open
+		 * @returns {boolean}
+		 */
+			_shouldattempt: function(open) {
+				var events = this.spirit.event;
+				if (open !== this.spirit.isOpen) {
+					return events.dispatch(open ? domevent.WILLOPEN : domevent.WILLCLOSE, {
+						bubbles: true,
+						cancelable: true
+					});
+				}
+				return false;
+			},
+
+			/**
+		 * Execute callback configured via HTML attribute or via JS property.
+		 * The 'this' keyword points to the element or the spirit respectively.
+		 * @type {String|function}
+		 * @returns {boolean}
+		 */
+			_execute: function(callback) {
+				var spirit = this.spirit;
+				if ((callback = spirit[callback])) {
+					switch (gui.Type.of(callback)) {
+						case 'string':
+							return new Function(callback).call(spirit);
+						case 'function':
+							return callback.call(spirit);
+					}
+				}
+				return true;
+			},
+
+			/**
+		 * Opening.
+		 * @param {boolean} animated (TODO)
+		 * @returns {boolean}
+		 */
+			_maybeopen: function(animated) {
+				var ok = this._execute('onopen') !== false;
+				if (ok) {
+					this.spirit.isOpen = true;
+					this.spirit.att.set('data-ts.open', true);
+					this.spirit.$onopen(animated);
+				}
+				return ok;
+			},
+
+			/**
+		 * Closing.
+		 * @param {boolean} animated (TODO)
+		 * @returns {boolean}
+		 */
+			_maybeclose: function(animated) {
+				var ok = this._execute('onclose') !== false;
+				if (ok) {
+					this.spirit.isOpen = false;
+					this.spirit.att.set('data-ts.open', false);
+					this.spirit.$onclose(animated);
+				}
+				return ok;
+			}
+		},
+		{
+			// Static ...............................................................
+
+			/**
+		 * 
+		 */
+			lazy: false
+		}
+	);
+})(gui.Type);

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/plugins/common/ts.ui.DoorManPlugin.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/plugins/common/ts.ui.DoorManPlugin.js
@@ -6,7 +6,7 @@
  */
 ts.ui.DoorManPlugin = (function(Type) {
 	// custom dom events (for public consumption)
-	// TODO: These are now used in SideBars and Modals and should be renamed
+	// TODO: These are now used in SideBars and Modals and should be renamed!!!!!!
 	var domevent = {
 		WILLOPEN: ts.ui.EVENT_ASIDE_WILL_OPEN,
 		DIDOPEN: ts.ui.EVENT_ASIDE_DID_OPEN,
@@ -17,24 +17,20 @@ ts.ui.DoorManPlugin = (function(Type) {
 	return ts.ui.Plugin.extend(
 		{
 			/**
-		 * TODO: Only in debug mode
-		 */
+			 * In debug mode, make sure that the host (spirit) is set up correctly.
+			 */
 			onconstruct: function() {
 				this.super.onconstruct();
-				var apis = 'isOpen onopen onopened onclose onclosed $onopen $onclose';
-				var host = this.spirit;
-				apis.split(' ').forEach(function(api) {
-					if (host[api] === undefined) {
-						throw new Error('Missing interface "' + api + '"');
-					}
-				});
+				if (gui.debug) {
+					this._confirminterface();
+				}
 			},
 
 			/**
-		 * Open AND close the aside (setup to support HTML `data-ts.open="true|false"`)
-		 * @param @optional {boolean} opt_open Omit to simply open.
-		 * @returns {boolean} True if allowed to open
-		 */
+			 * Open AND close the aside (setup to support HTML `data-ts.open="true|false"`)
+			 * @param @optional {boolean} opt_open Omit to simply open.
+			 * @returns {boolean} True if allowed to open
+			 */
 			open: function(opt_open) {
 				var spirit = this.spirit;
 				if (!Type.isBoolean(opt_open)) {
@@ -55,21 +51,22 @@ ts.ui.DoorManPlugin = (function(Type) {
 			},
 
 			/**
-		 *
-		 */
+			 * The host (spirit) should make sure to call this when fully opened.
+			 * This likely dependes on some CSS transition or animation or such.
+			 */
 			didopen: function() {
 				this._execute('onopened');
-				this.spirit.event.dispatch(domevent.DIDCLOSE, {
+				this.spirit.event.dispatch(domevent.DIDOPEN, {
 					bubbles: true
 				});
 			},
 
 			/**
-		 *
-		 */
+			 * The host (spirit) should make sure to call this when fully closed.
+			 */
 			didclose: function() {
 				this._execute('onclosed');
-				this.spirit.event.dispatch(domevent.DIDOPEN, {
+				this.spirit.event.dispatch(domevent.DIDCLOSE, {
 					bubbles: true
 				});
 			},
@@ -77,10 +74,10 @@ ts.ui.DoorManPlugin = (function(Type) {
 			// Private .................................................................
 
 			/**
-		 * Fire custom DOM event and return whether or not this was preventDefaulted.
-		 * @param {boolean} open
-		 * @returns {boolean}
-		 */
+			 * Fire custom DOM event and return whether or not this was preventDefaulted.
+			 * @param {boolean} open
+			 * @returns {boolean}
+			 */
 			_shouldattempt: function(open) {
 				var events = this.spirit.event;
 				if (open !== this.spirit.isOpen) {
@@ -93,11 +90,11 @@ ts.ui.DoorManPlugin = (function(Type) {
 			},
 
 			/**
-		 * Execute callback configured via HTML attribute or via JS property.
-		 * The 'this' keyword points to the element or the spirit respectively.
-		 * @type {String|function}
-		 * @returns {boolean}
-		 */
+			 * Execute callback configured via HTML attribute or via JS property.
+			 * The 'this' keyword points to the element or the spirit respectively.
+			 * @type {String|function}
+			 * @returns {boolean}
+			 */
 			_execute: function(callback) {
 				var spirit = this.spirit;
 				if ((callback = spirit[callback])) {
@@ -112,10 +109,10 @@ ts.ui.DoorManPlugin = (function(Type) {
 			},
 
 			/**
-		 * Opening.
-		 * @param {boolean} animated (TODO)
-		 * @returns {boolean}
-		 */
+			 * Opening.
+			 * @param {boolean} animated (TODO)
+			 * @returns {boolean}
+			 */
 			_maybeopen: function(animated) {
 				var ok = this._execute('onopen') !== false;
 				if (ok) {
@@ -127,10 +124,10 @@ ts.ui.DoorManPlugin = (function(Type) {
 			},
 
 			/**
-		 * Closing.
-		 * @param {boolean} animated (TODO)
-		 * @returns {boolean}
-		 */
+			 * Closing.
+			 * @param {boolean} animated (TODO)
+			 * @returns {boolean}
+			 */
 			_maybeclose: function(animated) {
 				var ok = this._execute('onclose') !== false;
 				if (ok) {
@@ -139,14 +136,28 @@ ts.ui.DoorManPlugin = (function(Type) {
 					this.spirit.$onclose(animated);
 				}
 				return ok;
+			},
+
+			/**
+			 * Confirm methods implemented or at least stubbed with `null`.
+			 */
+			_confirminterface: function() {
+				var apis = 'isOpen onopen onopened onclose onclosed $onopen $onclose';
+				var host = this.spirit;
+				apis.split(' ').forEach(function(api) {
+					if (host[api] === undefined) {
+						throw new Error('Missing interface "' + api + '"');
+					}
+				});
 			}
 		},
 		{
 			// Static ...............................................................
 
 			/**
-		 * 
-		 */
+			 * This plugins gets newed up automatically along with the spirit.
+			 * @type {boolean}
+			 */
 			lazy: false
 		}
 	);

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.AsideSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.AsideSpirit.js
@@ -8,14 +8,6 @@
  * @using {ts.ui.LayoutModel} LayoutModel
  */
 ts.ui.AsideSpirit = (function using(chained, confirmed, Client, LayoutModel, notontouch) {
-	// custom dom events (for public implementation)
-	var domevent = {
-		WILLOPEN: ts.ui.EVENT_ASIDE_WILL_OPEN,
-		DIDOPEN: ts.ui.EVENT_ASIDE_DID_OPEN,
-		WILLCLOSE: ts.ui.EVENT_ASIDE_WILL_CLOSE,
-		DIDCLOSE: ts.ui.EVENT_ASIDE_DID_CLOSE
-	};
-
 	// actions and broadcasts (for behind-the-scenes implementation)
 	var willopen = ts.ui.ACTION_ASIDE_WILL_OPEN,
 		didopen = ts.ui.ACTION_ASIDE_DID_OPEN,
@@ -372,33 +364,28 @@ ts.ui.AsideSpirit = (function using(chained, confirmed, Client, LayoutModel, not
 			 * TODO: Validate that we are not opening inside .ts-main
 			 * @param {boolean} animated (not supported just yet)
 			 */
-			_open: function(animated) {
-				if (this.super._open(animated)) {
-					this.super._open(animated);
-					this._delayedAngularInitialization();
-					this._trapattention();
-					this._willopen();
-					this._slideopen(true).then(
-						function done() {
-							this._ontransitionend();
-						}.bind(this)
-					);
-				}
+			$onopen: function(animated) {
+				this._delayedAngularInitialization();
+				this._trapattention();
+				this._willopen();
+				this._slideopen(true).then(
+					function done() {
+						this._ontransitionend();
+					}.bind(this)
+				);
 			},
 
 			/**
 			 * Close.
 			 * @param {boolean} animated (not supported)
 			 */
-			_close: function(animated) {
-				if (this.super._close(animated)) {
-					this._willclose();
-					this._slideopen(false).then(
-						function done() {
-							this._ontransitionend();
-						}.bind(this)
-					);
-				}
+			$onclose: function(animated) {
+				this._willclose();
+				this._slideopen(false).then(
+					function done() {
+						this._ontransitionend();
+					}.bind(this)
+				);
 			},
 
 			/**
@@ -497,10 +484,7 @@ ts.ui.AsideSpirit = (function using(chained, confirmed, Client, LayoutModel, not
 				this.key.addGlobal('Esc');
 				this.css.add(ts.ui.CLASS_OPEN);
 				this.guistatus.done('opening aside');
-				this._execute('onopened');
-				this.event.dispatch(domevent.DIDOPEN, {
-					bubbles: true
-				});
+				this.doorman.didopen();
 
 				/**
 				 * It would be nice to do this before the Aside opens,
@@ -555,11 +539,8 @@ ts.ui.AsideSpirit = (function using(chained, confirmed, Client, LayoutModel, not
 				this.guistatus.done('closing aside');
 				this.att.del('data-ts-offset');
 				this.attention.exit(panel);
-				this._execute('onclosed');
 				this.css.remove(ts.ui.CLASS_SECONDARY);
-				this.event.dispatch(domevent.DIDCLOSE, {
-					bubbles: true
-				});
+				this.doorman.didclose();
 				if (this._ismodelled()) {
 					this._model.status = 'onclosed';
 				}

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.SideBarSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.SideBarSpirit.js
@@ -168,7 +168,7 @@ ts.ui.SideBarSpirit = (function using(chained, Type, Client, GuiObject, Colors) 
 			 * TODO: Call `DoorManPlugin.didopen() when transition is done!
 			 */
 			$onopen: function() {
-				this.css.add('ts-will-open');
+				this.css.add(ts.ui.CLASS_OPENING);
 				this._reflex();
 				this.tick.time(function slide() {
 					this.css.add(ts.ui.CLASS_OPEN);
@@ -182,7 +182,7 @@ ts.ui.SideBarSpirit = (function using(chained, Type, Client, GuiObject, Colors) 
 			$onclose: function() {
 				this.css.remove(ts.ui.CLASS_OPEN);
 				this.tick.time(function undisplay() {
-					this.css.remove('ts-will-open');
+					this.css.remove(ts.ui.CLASS_OPENING);
 				}, ts.ui.TRANSITION_FAST);
 			},
 

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.SideBarSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.SideBarSpirit.js
@@ -161,7 +161,32 @@ ts.ui.SideBarSpirit = (function using(chained, Type, Client, GuiObject, Colors) 
 				ts.ui.removeBreakPointListener(this);
 			},
 
-			// Private .................................................................
+			// Privileged ............................................................
+
+			/**
+			 * Show the SideBar (now that it's hidden in mobile view).
+			 * TODO: Call `DoorManPlugin.didopen() when transition is done!
+			 */
+			$onopen: function() {
+				this.css.add('ts-will-open');
+				this._reflex();
+				this.tick.time(function slide() {
+					this.css.add(ts.ui.CLASS_OPEN);
+				});
+			},
+
+			/**
+			 * Don't show the SideBar.
+			 * TODO: Call `DoorManPlugin.didopen() when transition is done!
+			 */
+			$onclose: function() {
+				this.css.remove(ts.ui.CLASS_OPEN);
+				this.tick.time(function undisplay() {
+					this.css.remove('ts-will-open');
+				}, ts.ui.TRANSITION_FAST);
+			},
+
+			// Private ...............................................................
 
 			/**
 			 * Automatically close the SideBar in mobile breakpoint?
@@ -232,31 +257,6 @@ ts.ui.SideBarSpirit = (function using(chained, Type, Client, GuiObject, Colors) 
 							this.guilayout.flexGlobal();
 						}
 					}
-				}
-			},
-
-			/**
-			 * Show the SideBar (now that it's hidden in mobile view).
-			 */
-			_open: function() {
-				if (this.super._open()) {
-					this.css.add('ts-will-open');
-					this._reflex();
-					this.tick.time(function slide() {
-						this.css.add(ts.ui.CLASS_OPEN);
-					});
-				}
-			},
-
-			/**
-			 * Don't show the SideBar.
-			 */
-			_close: function() {
-				if (this.super._close()) {
-					this.css.remove(ts.ui.CLASS_OPEN);
-					this.tick.time(function undisplay() {
-						this.css.remove('ts-will-open');
-					}, ts.ui.TRANSITION_FAST);
 				}
 			},
 

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.SideShowSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/asides/ts.ui.SideShowSpirit.js
@@ -20,14 +20,6 @@ ts.ui.SideShowSpirit = (function using(
 	PANEL_ATTACH,
 	PANEL_DETACH
 ) {
-	// custom dom events (for public consumption)
-	var domevent = {
-		WILLOPEN: ts.ui.EVENT_ASIDE_WILL_OPEN,
-		DIDOPEN: ts.ui.EVENT_ASIDE_DID_OPEN,
-		WILLCLOSE: ts.ui.EVENT_ASIDE_WILL_CLOSE,
-		DIDCLOSE: ts.ui.EVENT_ASIDE_DID_CLOSE
-	};
-
 	// when synchronizing the colors, make sure to remove all existing colors...
 	var BGCOLORS = (function(colors) {
 		return Object.keys(colors).map(function(key) {
@@ -294,26 +286,12 @@ ts.ui.SideShowSpirit = (function using(
 			},
 
 			/**
-			 * Open AND close the aside (setup to support the HTML
-			 * attribute: `data-ts.open="true|false"`)
+			 * Open AND close the Aside (setup to support HTML `data-ts.open="true|false"`)
 			 * @param @optional {boolean} opt_open Omit to simply open.
 			 * @return {ts.ui.AsideSpirit}
 			 */
 			open: chained(function(opt_open) {
-				if (!gui.Type.isBoolean(opt_open)) {
-					opt_open = true;
-				}
-				if (this._shouldtoggle(opt_open)) {
-					if (opt_open) {
-						if (!this.isOpen) {
-							this._open(this.life.async);
-						}
-					} else {
-						if (this.isOpen) {
-							this._close(this.life.async);
-						}
-					}
-				}
+				this.doorman.open(opt_open);
 			}),
 
 			/**
@@ -321,7 +299,7 @@ ts.ui.SideShowSpirit = (function using(
 			 * @return {ts.ui.AsideSpirit}
 			 */
 			close: chained(function() {
-				this.open(false);
+				this.doorman.open(false);
 			}),
 
 			/**
@@ -352,7 +330,17 @@ ts.ui.SideShowSpirit = (function using(
 				}
 			}),
 
-			// Privileged ..............................................................
+			// Privileged ............................................................
+
+			/**
+			 * Required by the {DoorManPlugin}.
+			 */
+			$onopen: function() {},
+
+			/**
+			 * Required by the {DoorManPlugin}.
+			 */
+			$onclose: function() {},
 
 			/**
 			 * Actually flip the thing.
@@ -370,7 +358,7 @@ ts.ui.SideShowSpirit = (function using(
 				return this._flipping;
 			},
 
-			// Private .................................................................
+			// Private ...............................................................
 
 			/**
 			 * Snapshot the color scheme asigned via model.
@@ -455,24 +443,6 @@ ts.ui.SideShowSpirit = (function using(
 				if (!this.guilayout.outsideMain()) {
 					throw new Error(this + ' must be positioned outside Main', this.element);
 				}
-			},
-
-			/**
-			 * Runs on open and close. If the state changes:
-			 *
-			 * 1. Fire custom DOM event
-			 * 2. Return whether or not this was preventDefaulted.
-			 * @param {boolean} open
-			 * @returns {boolean}
-			 */
-			_shouldtoggle: function(open) {
-				if (open !== this.isOpen) {
-					return this.event.dispatch(open ? domevent.WILLOPEN : domevent.WILLCLOSE, {
-						bubbles: true,
-						cancelable: true
-					});
-				}
-				return false;
 			},
 
 			/**
@@ -590,35 +560,6 @@ ts.ui.SideShowSpirit = (function using(
 						}
 					}, 50);
 				}
-			},
-
-			/**
-			 * Opening scene implemented by subclass(es).
-			 * Except for the coloring stuff, apparently.
-			 * @param {boolean} animated
-			 * @returns {boolean}
-			 */
-			_open: function(animated) {
-				var success = this._execute('onopen') !== false;
-				if (success) {
-					this.isOpen = true;
-					this.att.set('data-ts.open', true);
-				}
-				return success;
-			},
-
-			/**
-			 * Closing stuff implemented by subclass(es).
-			 * @param {boolean} animated
-			 * @returns {boolean}
-			 */
-			_close: function(animated) {
-				var success = this._execute('onclose') !== false;
-				if (success) {
-					this.isOpen = false;
-					this.att.set('data-ts.open', false);
-				}
-				return success;
 			},
 
 			/**

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/modals/ts.ui.ModalSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/modals/ts.ui.ModalSpirit.js
@@ -332,6 +332,7 @@ ts.ui.ModalSpirit = (function using(Client, transition, chained) {
 				this.css.remove('ts-opening').add('ts-open');
 				this.broadcast.dispatch(didopen);
 				this._then.now(true);
+				this.doorman.didopen();
 				this._focus();
 			} else {
 				this.dom.show();
@@ -371,6 +372,7 @@ ts.ui.ModalSpirit = (function using(Client, transition, chained) {
 				this.tick.time(function() {
 					if (!this.$disposed) {
 						(this._main() || this).attention.exit();
+						this.doorman.didclose();
 					}
 				});
 			} else {

--- a/src/runtime/js/ts.ui/ts.ui.js
+++ b/src/runtime/js/ts.ui/ts.ui.js
@@ -335,6 +335,9 @@ ts.ui = gui.namespace(
 
 			// Events ..................................................................
 
+			/*
+			 * TODO: These are now used in SideBars and Modals and should be renamed
+			 */
 			EVENT_ASIDE_WILL_OPEN: 'ts-open',
 			EVENT_ASIDE_DID_OPEN: 'ts-opened',
 			EVENT_ASIDE_WILL_CLOSE: 'ts-close',

--- a/src/runtime/less/ts-sidebars.less
+++ b/src/runtime/less/ts-sidebars.less
@@ -39,7 +39,7 @@
 		.ts-panel {
 			box-shadow: none;
 		}
-		&.ts-will-open,
+		&.ts-opening,
 		&.ts-open {
 			display: block;
 		}
@@ -52,7 +52,7 @@
 		}
 		&.ts-2d {
 			top: 100%;
-			&.ts-will-open {
+			&.ts-opening {
 				height: 100%;
 				top: 0;
 			}

--- a/tasks/browserstack.js
+++ b/tasks/browserstack.js
@@ -226,7 +226,11 @@ const checkReport = function(report) {
 					errOut.push('Browser: ' + chalk.red.bold(browserRes.browser));
 					errOut.push(chalk.white.bgRed.bold(test.suiteName + ' > ' + test.name));
 					test.errors.forEach(function(err) {
-						errOut.push(chalk.red(err.stack.replace('/\\n/i', '\n')));
+						if (err.stack) {
+							errOut.push(chalk.red(err.stack.replace('/\\n/i', '\n')));
+						} else {
+							errOut.push(chalk.red('No stacktrace supplied :('));
+						}
 						errOut.push('');
 					});
 				} else {
@@ -241,13 +245,13 @@ const checkReport = function(report) {
 		}
 	});
 
-	console.log(out.join('\n'));
+	out.forEach(line => console.log(line));
 	if (!errOut.length) {
 		succ();
 	} else {
 		fail();
 	}
-	console.log(errOut.join('\n'));
+	errOut.forEach(line => console.log(line));
 
 	return !errOut.length;
 };


### PR DESCRIPTION
@zdlm @sampi

Fixes issue #281 - The business logic around `onopen`, `onopened`, `onclose` and `onclosed` are now handled by the DoorManPlugin. This includes the Spirit method overwrites, the inline-HTML callbacks and the custom DOM events. The Aside, Modal and SideBar have been rigged up to use this new plugin to ensure a consistent interface.

Since this is not what we are officially working on, I propose to postpone the unit tests until we are done with the Table enhancements. There is however real teams that appear to need the DoorManPlugin now, so I suggest we let them beta-test it straight away.
