### PR TITLE
[DocumentSpirit] Made the iOS bug `touchstart` listener passive

### DIFF
--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/document/ts.ui.DocumentSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/document/ts.ui.DocumentSpirit.js
@@ -70,7 +70,11 @@ ts.ui.DocumentSpirit = (function using(Client) {
 			if (ts.ui.appframe) {
 				var main = this.dom.qdoc('.ts-main');
 				if (main) {
-					main.addEventListener('touchstart', function() {});
+					main.addEventListener(
+						'touchstart',
+						function() {},
+						gui.Client.hasPassiveEventListeners ? { passive: true } : false
+					);
 				} else {
 					console.warn('WARNING: This app needs a ts-main');
 				}

--- a/src/spiritual/spiritual-gui/gui@wunderbyte.com/utils/gui.Client.js
+++ b/src/spiritual/spiritual-gui/gui@wunderbyte.com/utils/gui.Client.js
@@ -238,6 +238,25 @@ gui.Client = (function() {
 		this.hasPositionFixed = false;
 
 		/**
+		 * Supports `{passive: true}` as the third parameter of an EventListener?
+		 * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+		 * @see https://github.com/Modernizr/Modernizr/blob/master/feature-detects/dom/passiveeventlisteners.js
+		 * @type {boolean}
+		 */
+		this.hasPassiveEventListeners = (function() {
+			var supportsPassiveOption = false;
+			try {
+				var opts = Object.defineProperty({}, 'passive', {
+					get: function() {
+						supportsPassiveOption = true;
+					}
+				});
+				window.addEventListener('test', null, opts);
+			} catch (e) {}
+			return supportsPassiveOption;
+		})();
+
+		/**
 		 * Compute some stuff that couldn't be determined parse time.
 		 */
 		this.$init = function() {


### PR DESCRIPTION
@wiredearp @zdlm @sampi

Fixes issue #322

We should look into making other events passive as well, where it would improve scroll performance.


@wiredearp:
Do we still have that bug? Maybe we can just remove this whole thing