### PR TITLE
[gui.Tween] Fix IE compatibility

### DIFF
--- a/src/spiritual/spiritual-mix/gui-layout@wunderbyte.com/plugins/tween.plugin/gui.Tween.js
+++ b/src/spiritual/spiritual-mix/gui-layout@wunderbyte.com/plugins/tween.plugin/gui.Tween.js
@@ -108,7 +108,7 @@ gui.Tween = (function using(confirmed, chained) {
 				var easingCurve = gui.Tween.$easing.ease;
 				if (
 					typeof tween.timing === 'string' &&
-					Object.keys(gui.Tween.$easing).includes(tween.timing)
+					Object.keys(gui.Tween.$easing).indexOf(tween.timing) !== -1
 				) {
 					easingCurve = gui.Tween.$easing[tween.timing];
 				} else if (Array.isArray(tween.timing)) {


### PR DESCRIPTION
`Array.includes` isn’t supported =/

@wiredearp @zdlm @sampi
