### PR TITLE
Reset fallback scrollBarSize

### DIFF
--- a/src/spiritual/spiritual-gui/gui@wunderbyte.com/utils/gui.Client.js
+++ b/src/spiritual/spiritual-gui/gui@wunderbyte.com/utils/gui.Client.js
@@ -320,25 +320,6 @@ gui.Client = (function() {
 			}
 			html.removeChild(outer);
 			this.scrollBarSize = w1 - w2;
-
-			/**
-			 * Solid values, trust me
-			 * @see https://codepen.io/sambible/post/browser-scrollbar-widths
-			 * @see http://www.textfixer.com/tutorials/scrollbar-pixel-width-test.php
-			 */
-			if (!this.scrollBarSize && !this.isTouchDevice) {
-				if (this.system === 'windows') {
-					if (this.isEdge) {
-						this.scrollBarSize = 12;
-					} else {
-						this.scrollBarSize = 17;
-					}
-				} else if (this.system === 'linux' && this.isGecko) {
-					this.scrollBarSize = 16;
-				} else {
-					this.scrollBarSize = 15;
-				}
-			}
 		};
 	}
 


### PR DESCRIPTION
@kaumac @zdlm @sampi

Fixes issue #374 + #390

The fallback scrollbar size seems to have caused more issues than it fixed, so we'll revert to the old behavior. Whatever it was, the issue only appeared in the New Chrome and Tradeshift UI is no longer in the chrome.
