### PR TITLE
Suspend/resume API for working with bottomless DOM

### DIFF
--- a/src/runtime/js/ts.ui/ts.ui.js
+++ b/src/runtime/js/ts.ui/ts.ui.js
@@ -511,6 +511,26 @@ ts.ui = gui.namespace(
 				});
 			},
 
+			/**
+			 * Don't materialize and spiritualize during given operation.
+			 * If the operation is async, use `suspend()` and `resume()`.
+			 * @param {funtion} [operation] Assumed synchronous!
+			 */
+			suspend: function(operation) {
+				if (arguments.length) {
+					return gui.suspend.apply(gui, operation);
+				} else {
+					gui.suspend();
+				}
+			},
+
+			/** 
+			 * Resume spiritualization and materialization.
+			 */
+			resume: function() {
+				gui.resume();
+			},
+
 			// Private .................................................................
 
 			/**

--- a/src/runtime/js/ts.ui/ts.ui.js
+++ b/src/runtime/js/ts.ui/ts.ui.js
@@ -515,10 +515,11 @@ ts.ui = gui.namespace(
 			 * Don't materialize and spiritualize during given operation.
 			 * If the operation is async, use `suspend()` and `resume()`.
 			 * @param {funtion} [operation] Assumed synchronous!
+			 * @param {Object} [thisp]
 			 */
-			suspend: function(operation) {
+			suspend: function(operation, thisp) {
 				if (arguments.length) {
-					return gui.suspend.call(gui, operation);
+					return gui.suspend.apply(gui, arguments);
 				} else {
 					gui.suspend();
 				}

--- a/src/runtime/js/ts.ui/ts.ui.js
+++ b/src/runtime/js/ts.ui/ts.ui.js
@@ -518,7 +518,7 @@ ts.ui = gui.namespace(
 			 */
 			suspend: function(operation) {
 				if (arguments.length) {
-					return gui.suspend.apply(gui, operation);
+					return gui.suspend.call(gui, operation);
 				} else {
 					gui.suspend();
 				}

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/channeling/gui.Guide.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/channeling/gui.Guide.js
@@ -40,15 +40,28 @@ gui.Guide = (function using(
 
 		/**
 		 * Suspend spiritualization and materialization during operation.
-		 * @param {function} operation
+		 * If the operation is async, use `suspend()` and later `resume()`.
+		 * @param {function} operation - This is assumed synchronous!
 		 * @param @optional {object} thisp
-		 * @returns {object}
+		 * @returns {*|this}
 		 */
 		suspend: function(operation, thisp) {
 			this._suspended = true;
-			var res = operation.call(thisp);
+			if (operation) {
+				var res = operation.call(thisp);
+				this._suspended = false;
+				return res;
+			}
+			return this;
+		},
+
+		/**
+		 * Resume spiritualization and materialization.
+		 * @returns {this}
+		 */
+		resume: function() {
 			this._suspended = false;
-			return res;
+			return this;
 		},
 
 		// Privileged ..............................................................

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/gui.extensions.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/gui.extensions.js
@@ -195,12 +195,26 @@ gui = gui.Object.extend(
 
 		/**
 		 * Don't materialize and spiritualize during given operation.
-		 * @param {funtion} operation
+		 * If the operation is async, use `suspend()` and `resume()`.
+		 * @param {funtion} [operation] Assumed synchronous!
 		 */
 		suspend: function(operation) {
-			return gui.DOMObserver.suspend(function() {
-				return gui.Guide.suspend(operation);
-			});
+			if (arguments.length) {
+				return gui.DOMObserver.suspend(function() {
+					return gui.Guide.suspend(operation);
+				});
+			} else {
+				gui.DOMObserver.suspend();
+				gui.Guide.suspend();
+			}
+		},
+
+		/** 
+		 * Resume spiritualization and materialization.
+		 */
+		resume: function() {
+			gui.DOMObserver.resume();
+			gui.Guide.resume();
 		},
 
 		/**

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/gui.extensions.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/gui.extensions.js
@@ -197,11 +197,12 @@ gui = gui.Object.extend(
 		 * Don't materialize and spiritualize during given operation.
 		 * If the operation is async, use `suspend()` and `resume()`.
 		 * @param {funtion} [operation] Assumed synchronous!
+		 * @param {Object} [thisp]
 		 */
-		suspend: function(operation) {
+		suspend: function(operation, thisp) {
 			if (arguments.length) {
 				return gui.DOMObserver.suspend(function() {
-					return gui.Guide.suspend(operation);
+					return gui.Guide.suspend(operation, thisp);
 				});
 			} else {
 				gui.DOMObserver.suspend();

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMObserver.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/mutations/gui.DOMObserver.js
@@ -196,9 +196,9 @@ gui.DOMObserver = (function using(Type, GuiArray) {
 		 * Suspend mutation monitoring of document; enable
 		 * monitoring again after executing provided function.
 		 * @param {Node} node
-		 * @param @optional {function} action
-		 * @param @optional {object} thisp
-		 * @returns {object} if action was defined, we might return something
+		 * @param {function} [action] Assumed synchronous!
+		 * @param {object} [thisp]
+		 * @returns {*|this} if action was defined, we might return something
 		 */
 		suspend: function(action, thisp) {
 			var res;


### PR DESCRIPTION
@zdlm @sampi @kaumac @upphiminn 

Fixes unreported issue: Maximum callstack comes crashing down when the DOM becomes super big all of a sudden. This could normally be fixed with the undocumented API:

```js
gui.suspend(appendonebillionproducts);
```

... but if that callback is async, we would resume normal operation before the DOM was updated. Now you can say:

```js
ts.ui.suspend();
appendonebillionproducts();
setTimeout(() => ts.ui.resume(), 23000);
```
... at least if you are not so lucky that the expensive operation should return a Promise that can replace the timeout.