### PR TITLE
Tabs (supposed) hotfix

### DIFF
--- a/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/toolbar/ts.ui.ToolBarSpirit.js
+++ b/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/toolbar/ts.ui.ToolBarSpirit.js
@@ -759,6 +759,7 @@ ts.ui.ToolBarSpirit = (function using(
 						dofit = this._toggletabs(tabs, width, avail);
 						moretab.css.display = dofit ? 'none' : '';
 						if (!dofit) {
+							this._hotfix();
 							// make sure selected tab is visible
 							if (
 								(gonetab = tabs.find(function ishidden(tab) {
@@ -769,6 +770,28 @@ ts.ui.ToolBarSpirit = (function using(
 							}
 						}
 					}
+				}
+			},
+
+			/**
+			 * The window may sometimes report the wrong dimensions (inside the 
+			 * iframe) under strange and unknown conditions, so whenever we see 
+			 * that the tabs are determined not to fit on the screen, we simply 
+			 * setup to perform the calculation again after some 50 millisecs. 
+			 * The tabs will (or should at least) be refactored completely on 
+			 * the `10.x` branch to eliminate much of this JS layout (via flex), 
+			 * so there is no reason to make a big deal out of a proper fix if 
+			 * this can hotfix it on the short term (it's a big deal because 
+			 * the problem cannot be reproduced locally, or at least not by @jmo).
+			 * the tabs to be rendered 
+			 */
+			_hotfix: function hotfix() {
+				if (!hotfix.running) {
+					this.tick.time(function reflex() {
+						hotfix.running = true;
+						this.reflex();
+						hotfix.running = false;
+					}, 50);
 				}
 			},
 

--- a/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/toolbar/ts.ui.ToolBarSpirit.js
+++ b/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/toolbar/ts.ui.ToolBarSpirit.js
@@ -787,8 +787,8 @@ ts.ui.ToolBarSpirit = (function using(
 			 */
 			_hotfix: function hotfix() {
 				if (!hotfix.running) {
+					hotfix.running = true;
 					this.tick.time(function reflex() {
-						hotfix.running = true;
 						this.reflex();
 						hotfix.running = false;
 					}, 50);


### PR DESCRIPTION
@kaumac @zdlm @sampi 

Hotfix for wrong window dimensions reported during app initialization: If the tabs are determined not to fit on the screen, we simply timeout to evaluate this  conclusion again after 50 milliseconds. We can replace a lot of this sketchy JS with flex layout (on the 10.x branch), so I propose that there is no reason to make a big deal out of it. It is very hard to properly fix, because the phenomenon does not occur on localhost.

Fixes issue reported on Slack (only)
