### PR TITLE
Don't `onidle` after `onsearch` (on input blurred) unless the value has changed

### DIFF
--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.InputSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.InputSpirit.js
@@ -106,6 +106,7 @@ ts.ui.InputSpirit = (function using(chained, Type, Client) {
 				switch (e.type) {
 					case 'keydown':
 						if (e.keyCode === 13) {
+							this._snapshot = this.value;
 							this._onenterkey(e);
 						}
 						break;
@@ -125,7 +126,9 @@ ts.ui.InputSpirit = (function using(chained, Type, Client) {
 						break;
 					case 'blur':
 						this.event.remove('keydown');
-						this._oncount();
+						if (this.value !== this._snapshot) {
+							this._oncount();
+						}
 						if (model) {
 							model.focused = false;
 						}


### PR DESCRIPTION
@kaumac @zdlm @sampi

Fixes issue #489 - SEARCH input. Making sure not to call `onidle` after `onsearch` if and when the input is blurred *unless* the input value has been changed in the meantime ✌️
