### PR TITLE
Don't destroy the tabs when switching breakpoint + release to "npm" folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function(grunt) {
 		clean: {
 			dev: ['temp/**', 'dist/**', 'public/**'],
 			jasmine: ['temp/**', 'dist/**', 'public/**'],
-			cdn: ['temp/**', 'dist/cdn/**', 'public/**']
+			cdn: ['temp/**', 'dist/cdn/**', 'dist/npm/**', 'public/**']
 		},
 
 		copy: {
@@ -92,6 +92,10 @@ module.exports = function(grunt) {
 						dest: 'dist/cdn/ts-<%= pkg.version %>.css'
 					},
 					{
+						src: 'dist/ts.css',
+						dest: 'dist/npm/ts.css'
+					},
+					{
 						src: 'dist/ts.min.css',
 						dest: 'dist/cdn/ts-<%= pkg.version %>.min.css'
 					}
@@ -102,8 +106,16 @@ module.exports = function(grunt) {
 		tsless: {
 			// concatenate the LESS (so that devs may copy-paste it from the web)
 			cdn: {
-				src: 'src/runtime/less/include.less',
-				dest: 'dist/cdn/ts-runtime-<%= pkg.version %>.less'
+				files: [
+					{
+						src: 'src/runtime/less/include.less',
+						dest: 'dist/cdn/ts-runtime-<%= pkg.version %>.less'
+					},
+					{
+						src: 'src/runtime/less/include.less',
+						dest: 'dist/npm/ts.less'
+					}
+				]
 			},
 			// concatenate the LESS (so a local dev can see what's going in the file)
 			dev: {
@@ -145,7 +157,8 @@ module.exports = function(grunt) {
 			cdn: {
 				options: getbuildoptions(),
 				files: {
-					'dist/cdn/ts-<%= pkg.version %>.js': getcombobuilds()
+					'dist/cdn/ts-<%= pkg.version %>.js': getcombobuilds(),
+					'dist/npm/ts.js': getcombobuilds()
 				}
 			},
 			// all the ts js spec files

--- a/src/runtime/edbml/functions/ts.ui.toolbartabs.edbml
+++ b/src/runtime/edbml/functions/ts.ui.toolbartabs.edbml
@@ -7,8 +7,9 @@
     
   (function specialTabs(topbar) {
     @ts = topbar ? 'ts.ui.TopBarTabsSpirit' : null;
+    @id = id + ( topbar && mobilos ? '-dropdown' : '-tabs' );
     @class = 'ts-toolbar-tabs' + (topbar ? ' ts-topbar-tabs' : '');
-    <ul @ts @class id="${id}-tabs">
+    <ul @ts @class @id>
       tabs.forEach(rendertab);
       if(tabs.newtabbutton) {
         rendernew(tabs.newtabbutton);

--- a/src/runtime/edbml/scripts/ts.ui.ToolBarSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.ToolBarSpirit.edbml
@@ -3,7 +3,7 @@
 	<?input name="toolbar" type="ts.ui.ToolBarModel"?>
 	<?input name="layout" type="ts.ui.LayoutModel"?>
 	<?function name="renderTabs" src="ts.ui.toolbartabs.edbml"?>
-
+	
 	var spirit = this;
 	var id = spirit.$instanceid + toolbar.$instanceid;
 	var mobilos = layout.isMobilePoint();
@@ -28,15 +28,15 @@
 		var hasnavi = !!(topbar && navigation && navigation.getLength());
 		var hastabs = !!tabs.getLength();
 		var hasactions = !!actions.length;
-		if(mobilos || status || search || checkbox || hasactions || hastabs || hasnavi || (topbar ? hasrealtitle : title)) {
-			if(mobilos && hastabs) {
+		if(status || search || checkbox || hasactions || hastabs || hasnavi || (topbar ? hasrealtitle : title)) {
+			if(topbar && mobilos && hastabs) {
 				renderTabs(spirit, tabs, id, mobilos);
 			}
 			<menu id="${id}-items" class="ts-toolbar-menu ts-left">
-				if(topbar) {
+				if (topbar) {
 					renderNav(navigation);
 				}
-				if(!mobilos && hastabs && !hasnavi) {
+				if ((!mobilos || !topbar) && hastabs && !hasnavi) {
 					renderTabs(spirit, tabs, id, mobilos);
 				} else {
 				 if(search) {

--- a/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/topbar/ts.ui.TopBarModel.js
+++ b/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/topbar/ts.ui.TopBarModel.js
@@ -47,7 +47,6 @@ ts.ui.TopBarModel = (function using(chained) {
 			this.super.onconstruct();
 			gui.Broadcast.addGlobal([UPDATE_DEFAULT_TITLE], this);
 			this.menubutton = {
-				id: 'ts-button-menuswitch',
 				icon: 'ts-icon-menuswitch',
 				type: 'ts-tertiary ts-topbar-menubutton',
 				onclick: function() {


### PR DESCRIPTION
@zdlm @kaumac @sampi

Fixes issue #443 - Does not re-render itself when going from ts-mobile to ts-tablet/ts-desktop

It was caused by a mistake in the EDBML where tabs would be moved around in the DOM for no good reason *plus* a real bug in the DOM diffing and patching mechanism. I chose to work around the latter (with a workaround that involves changing the IDs on breakpoint transition instead of reusing them) because there is no way to tell how long a real fix will take. We would almost certainly be breaking other things in the process. Once we have a lot of time on hand, I suggest that we should look into it again 🍺 or simply use the rewritten algorithm once IE11 is deprecated, whichever happens first. 

Also: The `grunt dist` job will now build a folder called `npm` next to `cdn` where the file names remain unversioned. They will simply look like this:

* `ts.js`
* `ts.css`
* `ts.less*
 
Note that the LESS file doesn't include the usual `-runtime` suffix (in this particular folder). This should allow us to get rid of the regular expressions found in the job found on https://ci.ts.sv/job/tradeshift-ui-npm-publish/configure cc @wejendorp