### PR TITLE
Don't render no destructed spirit

### DIFF
--- a/src/spiritual/spiritual-edbml/edbml@wunderbyte.com/plugins/edbml.ScriptPlugin.js
+++ b/src/spiritual/spiritual-edbml/edbml@wunderbyte.com/plugins/edbml.ScriptPlugin.js
@@ -124,7 +124,9 @@ edbml.ScriptPlugin = (function using(
 		 */
 		run: function(/* arguments */) {
 			Tick.cancelFrame(this._frameindex);
-			if (this.loaded) {
+			if (!this.spirit || this.spirit.$destructed) {
+				console.warn('Attempt to handle destructed spirit');
+			} else if (this.loaded) {
 				if (!this.$input || this.$input.done) {
 					if (this.spirit.life.entered) {
 						this.write(this._run.apply(this, arguments));


### PR DESCRIPTION
@kaumac @zdlm @sampi @jmredfern 

This could lead to exceptions. Let's downgrade that to a warning in the
console. Fixes an unreported issue discovered in Slack.