### PR TITLE
(Perhaps) update the Switch for Angular 1.5

### DIFF
--- a/docs/dist/appendix/autofocus/index.html
+++ b/docs/dist/appendix/autofocus/index.html
@@ -5,11 +5,11 @@
     <title>Automagic Focus</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <script src="index.js"></script>
     <style>

--- a/docs/dist/appendix/autolayout/index.html
+++ b/docs/dist/appendix/autolayout/index.html
@@ -5,11 +5,11 @@
     <title>Automated Layout</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <script>
         var LayoutModel = ts.ui.Model.extend({

--- a/docs/dist/appendix/colors/index.html
+++ b/docs/dist/appendix/colors/index.html
@@ -5,11 +5,11 @@
     <title>Colors</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/appendix/index.html
+++ b/docs/dist/appendix/index.html
@@ -5,11 +5,11 @@
     <title>Appendix</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/appendix/markdown/index.html
+++ b/docs/dist/appendix/markdown/index.html
@@ -5,11 +5,11 @@
     <title>Markdown</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <script src="index.js"></script>
     <link rel="stylesheet" href="index.css">

--- a/docs/dist/appendix/responsive/index.html
+++ b/docs/dist/appendix/responsive/index.html
@@ -5,11 +5,11 @@
     <title>Responsive Design</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <style>

--- a/docs/dist/appendix/typo/index.html
+++ b/docs/dist/appendix/typo/index.html
@@ -5,11 +5,11 @@
     <title>Typography</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="typo.css">
 </head>

--- a/docs/dist/components/api-only.html
+++ b/docs/dist/components/api-only.html
@@ -5,11 +5,11 @@
     <title>API-only Components</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Inline" href="index.html">
     <link rel="prefetch" title="API-only" href="api-only.html">

--- a/docs/dist/components/asides/index.html
+++ b/docs/dist/components/asides/index.html
@@ -5,11 +5,11 @@
     <title>Aside HTML</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="JS" href="js.html">

--- a/docs/dist/components/asides/js.html
+++ b/docs/dist/components/asides/js.html
@@ -5,11 +5,11 @@
     <title>Aside JS</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="JS" href="js.html">

--- a/docs/dist/components/asides/test-1.html
+++ b/docs/dist/components/asides/test-1.html
@@ -5,11 +5,11 @@
     <title>Aside Test One</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <link rel="prefetch" title="HTML" href="index.html">

--- a/docs/dist/components/bars/statusbar-DEPRECATED.html
+++ b/docs/dist/components/bars/statusbar-DEPRECATED.html
@@ -5,11 +5,11 @@
     <title>StatusBar</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="TopBar" href="topbar.html">
     <link rel="prefetch" title="TabBar" href="tabbar.html">

--- a/docs/dist/components/bars/tabbar.html
+++ b/docs/dist/components/bars/tabbar.html
@@ -5,11 +5,11 @@
     <title>TabBar</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="TopBar" href="topbar.html">
     <link rel="prefetch" title="TabBar" href="tabbar.html">

--- a/docs/dist/components/bars/toolbar.html
+++ b/docs/dist/components/bars/toolbar.html
@@ -5,11 +5,11 @@
     <title>ToolBar</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="TopBar" href="topbar.html">
     <link rel="prefetch" title="TabBar" href="tabbar.html">

--- a/docs/dist/components/bars/topbar.html
+++ b/docs/dist/components/bars/topbar.html
@@ -5,11 +5,11 @@
     <title>TopBar</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="TopBar" href="topbar.html">
     <link rel="prefetch" title="TabBar" href="tabbar.html">

--- a/docs/dist/components/buttons/buttons.html
+++ b/docs/dist/components/buttons/buttons.html
@@ -5,11 +5,11 @@
     <title>Buttons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Button" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/buttons/gallery.html
+++ b/docs/dist/components/buttons/gallery.html
@@ -5,11 +5,11 @@
     <title>Button Gallery</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Button" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/buttons/index.html
+++ b/docs/dist/components/buttons/index.html
@@ -5,11 +5,11 @@
     <title>Button</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Button" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/cards/companycard.html
+++ b/docs/dist/components/cards/companycard.html
@@ -5,11 +5,11 @@
     <title>CompanyCard</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="CompanyCard" href="companycard.html">
     <link rel="prefetch" title="UserCard" href="usercard.html">

--- a/docs/dist/components/cards/extras.html
+++ b/docs/dist/components/cards/extras.html
@@ -5,11 +5,11 @@
     <title>CompanyCard extras</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="CompanyCard" href="companycard.html">
     <link rel="prefetch" title="UserCard" href="usercard.html">

--- a/docs/dist/components/cards/usercard.html
+++ b/docs/dist/components/cards/usercard.html
@@ -5,11 +5,11 @@
     <title>UserCard</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="CompanyCard" href="companycard.html">
     <link rel="prefetch" title="UserCard" href="usercard.html">

--- a/docs/dist/components/datepicker/index.html
+++ b/docs/dist/components/datepicker/index.html
@@ -5,11 +5,11 @@
     <title>DatePicker</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/components/dialogs/index.html
+++ b/docs/dist/components/dialogs/index.html
@@ -5,11 +5,11 @@
     <title>Dialog</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/components/footer/actions.html
+++ b/docs/dist/components/footer/actions.html
@@ -5,11 +5,11 @@
     <title>Footer Actions</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Footer" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/footer/buttons.html
+++ b/docs/dist/components/footer/buttons.html
@@ -5,11 +5,11 @@
     <title>Footer Buttons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Footer" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/footer/collabbutton.html
+++ b/docs/dist/components/footer/collabbutton.html
@@ -5,11 +5,11 @@
     <title>Footer Collaboration</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Footer" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/footer/configbutton.html
+++ b/docs/dist/components/footer/configbutton.html
@@ -5,11 +5,11 @@
     <title>Footer Configuration</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Footer" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/footer/gallery.html
+++ b/docs/dist/components/footer/gallery.html
@@ -5,11 +5,11 @@
     <title>Footer Gallery</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Footer" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/footer/index.html
+++ b/docs/dist/components/footer/index.html
@@ -5,11 +5,11 @@
     <title>Footer Pager</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Footer" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/footer/pager.html
+++ b/docs/dist/components/footer/pager.html
@@ -5,11 +5,11 @@
     <title>Footer Pager</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Footer" href="index.html">
     <link rel="prefetch" title="Buttons" href="buttons.html">

--- a/docs/dist/components/forms/autocomplete.html
+++ b/docs/dist/components/forms/autocomplete.html
@@ -5,11 +5,11 @@
     <title>Form Autocomplete</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="Disabled / Readonly" href="disabled.html">

--- a/docs/dist/components/forms/custom-select.html
+++ b/docs/dist/components/forms/custom-select.html
@@ -5,11 +5,11 @@
     <title>Custom Select</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="Disabled / Readonly" href="disabled.html">

--- a/docs/dist/components/forms/disabled.html
+++ b/docs/dist/components/forms/disabled.html
@@ -5,11 +5,11 @@
     <title>Disabled &amp; Readonly Fields</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="Disabled / Readonly" href="disabled.html">

--- a/docs/dist/components/forms/example.html
+++ b/docs/dist/components/forms/example.html
@@ -5,11 +5,11 @@
     <title>Form Example</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="Disabled / Readonly" href="disabled.html">

--- a/docs/dist/components/forms/index.html
+++ b/docs/dist/components/forms/index.html
@@ -5,11 +5,11 @@
     <title>Form</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="Disabled / Readonly" href="disabled.html">

--- a/docs/dist/components/forms/redesign.html
+++ b/docs/dist/components/forms/redesign.html
@@ -5,11 +5,11 @@
     <title>Form Example</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="Disabled / Readonly" href="disabled.html">

--- a/docs/dist/components/forms/test-1.html
+++ b/docs/dist/components/forms/test-1.html
@@ -5,11 +5,11 @@
     <title>Form Test</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <link rel="prefetch" title="HTML" href="index.html">

--- a/docs/dist/components/icons/css.html
+++ b/docs/dist/components/icons/css.html
@@ -5,11 +5,11 @@
     <title>Icons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="css.css">
     <link rel="prefetch" title="HTML" href="index.html">

--- a/docs/dist/components/icons/iconspirit.html
+++ b/docs/dist/components/icons/iconspirit.html
@@ -5,11 +5,11 @@
     <title>Icons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="list.css">
     <link rel="prefetch" title="HTML" href="index.html">

--- a/docs/dist/components/icons/index.html
+++ b/docs/dist/components/icons/index.html
@@ -5,11 +5,11 @@
     <title>Icons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="CSS" href="css.html">

--- a/docs/dist/components/icons/list.html
+++ b/docs/dist/components/icons/list.html
@@ -5,11 +5,11 @@
     <title>Icons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="list.css">
     <link rel="prefetch" title="HTML" href="index.html">

--- a/docs/dist/components/index.html
+++ b/docs/dist/components/index.html
@@ -5,11 +5,11 @@
     <title>Inline Components</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Inline" href="index.html">
     <link rel="prefetch" title="API-only" href="api-only.html">

--- a/docs/dist/components/menus/index.html
+++ b/docs/dist/components/menus/index.html
@@ -5,11 +5,11 @@
     <title>Menu</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/components/modals/index.html
+++ b/docs/dist/components/modals/index.html
@@ -5,11 +5,11 @@
     <title>Modal</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <script>

--- a/docs/dist/components/notes/index.html
+++ b/docs/dist/components/notes/index.html
@@ -5,11 +5,11 @@
     <title>Note</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <script>
         function toggle( /*...selectors*/ ) {

--- a/docs/dist/components/notifications/index.html
+++ b/docs/dist/components/notifications/index.html
@@ -5,11 +5,11 @@
     <title>Notification</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <script>
         // Setup to quicktest the markdown parser

--- a/docs/dist/components/pager/index.html
+++ b/docs/dist/components/pager/index.html
@@ -5,11 +5,11 @@
     <title>Pager</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/components/panels/index.html
+++ b/docs/dist/components/panels/index.html
@@ -5,11 +5,11 @@
     <title>Panels</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/components/search/index.html
+++ b/docs/dist/components/search/index.html
@@ -5,11 +5,11 @@
     <title>Search</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/components/sidebars/index.html
+++ b/docs/dist/components/sidebars/index.html
@@ -5,11 +5,11 @@
     <title>SideBars</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="HTML" href="index.html">
     <link rel="prefetch" title="Test" href="test-1.html" class="hidden">

--- a/docs/dist/components/sidebars/test-1.html
+++ b/docs/dist/components/sidebars/test-1.html
@@ -5,11 +5,11 @@
     <title>SideBars Test One</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <link rel="prefetch" title="HTML" href="index.html">

--- a/docs/dist/components/spinners/index.html
+++ b/docs/dist/components/spinners/index.html
@@ -5,11 +5,11 @@
     <title>Spinner</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <script>
         function spin(elm) {

--- a/docs/dist/components/table/actions.html
+++ b/docs/dist/components/table/actions.html
@@ -5,11 +5,11 @@
     <title>Table Actions</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/angular.html
+++ b/docs/dist/components/table/angular.html
@@ -5,11 +5,11 @@
     <title>Table Demo</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <script src="/dist/assets/angular-1.3.6.min.js"></script>

--- a/docs/dist/components/table/building.html
+++ b/docs/dist/components/table/building.html
@@ -5,11 +5,11 @@
     <title>Table Build</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/buttons.html
+++ b/docs/dist/components/table/buttons.html
@@ -5,11 +5,11 @@
     <title>Table Buttons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/clicking.html
+++ b/docs/dist/components/table/clicking.html
@@ -5,11 +5,11 @@
     <title>Table Click</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/collaborate.html
+++ b/docs/dist/components/table/collaborate.html
@@ -5,11 +5,11 @@
     <title>Table Collaboration</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/configuring.html
+++ b/docs/dist/components/table/configuring.html
@@ -5,11 +5,11 @@
     <title>Table Config</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/demo.html
+++ b/docs/dist/components/table/demo.html
@@ -5,11 +5,11 @@
     <title>Table Demo</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/editing.html
+++ b/docs/dist/components/table/editing.html
@@ -5,11 +5,11 @@
     <title>Table Edit</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/extras.html
+++ b/docs/dist/components/table/extras.html
@@ -5,11 +5,11 @@
     <title>Table Extras</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/filtering.html
+++ b/docs/dist/components/table/filtering.html
@@ -5,11 +5,11 @@
     <title>Table Filter</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/formatting.html
+++ b/docs/dist/components/table/formatting.html
@@ -5,11 +5,11 @@
     <title>Table Formatting</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/gallery.html
+++ b/docs/dist/components/table/gallery.html
@@ -5,11 +5,11 @@
     <title>Table Gallery</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <link rel="prefetch" title="Table" href="index.html">

--- a/docs/dist/components/table/gutter.html
+++ b/docs/dist/components/table/gutter.html
@@ -5,11 +5,11 @@
     <title>Table Floating Gutter</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <link rel="prefetch" title="Table" href="index.html">

--- a/docs/dist/components/table/index.html
+++ b/docs/dist/components/table/index.html
@@ -5,11 +5,11 @@
     <title>Table</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/layouting.html
+++ b/docs/dist/components/table/layouting.html
@@ -5,11 +5,11 @@
     <title>Table Layout</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/maximize.html
+++ b/docs/dist/components/table/maximize.html
@@ -5,11 +5,11 @@
     <title>Table explode and optimize</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/paging.html
+++ b/docs/dist/components/table/paging.html
@@ -5,11 +5,11 @@
     <title>Table Paging</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/searching.html
+++ b/docs/dist/components/table/searching.html
@@ -5,11 +5,11 @@
     <title>Table Search</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/selecting.html
+++ b/docs/dist/components/table/selecting.html
@@ -5,11 +5,11 @@
     <title>Table Select</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/sorting.html
+++ b/docs/dist/components/table/sorting.html
@@ -5,11 +5,11 @@
     <title>Table Sort</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/status.html
+++ b/docs/dist/components/table/status.html
@@ -5,11 +5,11 @@
     <title>Table Sort</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/table/styling.html
+++ b/docs/dist/components/table/styling.html
@@ -5,11 +5,11 @@
     <title>Table Styling</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Table" href="index.html">
     <link rel="prefetch" title="Build" href="building.html">

--- a/docs/dist/components/times/index.html
+++ b/docs/dist/components/times/index.html
@@ -5,11 +5,11 @@
     <title>Time</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Time" href="index.html">
     <link rel="prefetch" title="Local Time" href="langs.html" class="hidden">

--- a/docs/dist/components/times/langs.html
+++ b/docs/dist/components/times/langs.html
@@ -5,11 +5,11 @@
     <title>Local Time</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Time" href="index.html">
     <link rel="prefetch" title="Local Time" href="langs.html" class="hidden">

--- a/docs/dist/components/userimages/index.html
+++ b/docs/dist/components/userimages/index.html
@@ -5,11 +5,11 @@
     <title>UserImage</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/design/copy/buttons.html
+++ b/docs/dist/design/copy/buttons.html
@@ -5,11 +5,11 @@
     <title>Buttons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Principles" href="index.html">
     <link rel="prefetch" title="Development" href="dev.html">

--- a/docs/dist/design/copy/dev.html
+++ b/docs/dist/design/copy/dev.html
@@ -5,11 +5,11 @@
     <title>Copy in the Development Process</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Principles" href="index.html">
     <link rel="prefetch" title="Development" href="dev.html">

--- a/docs/dist/design/copy/emails.html
+++ b/docs/dist/design/copy/emails.html
@@ -5,11 +5,11 @@
     <title>Emails</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Principles" href="index.html">
     <link rel="prefetch" title="Development" href="dev.html">

--- a/docs/dist/design/copy/errors.html
+++ b/docs/dist/design/copy/errors.html
@@ -5,11 +5,11 @@
     <title>Error Messages</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Principles" href="index.html">
     <link rel="prefetch" title="Development" href="dev.html">

--- a/docs/dist/design/copy/index.html
+++ b/docs/dist/design/copy/index.html
@@ -5,11 +5,11 @@
     <title>UI Copy Principles</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Principles" href="index.html">
     <link rel="prefetch" title="Development" href="dev.html">

--- a/docs/dist/design/copy/pickers.html
+++ b/docs/dist/design/copy/pickers.html
@@ -5,11 +5,11 @@
     <title>Menu Pickers</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Principles" href="index.html">
     <link rel="prefetch" title="Development" href="dev.html">

--- a/docs/dist/design/copy/terms.html
+++ b/docs/dist/design/copy/terms.html
@@ -5,11 +5,11 @@
     <title>Terminology &amp; Cheat Sheet</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="Principles" href="index.html">
     <link rel="prefetch" title="Development" href="dev.html">

--- a/docs/dist/design/index.html
+++ b/docs/dist/design/index.html
@@ -5,11 +5,11 @@
     <title>Design Principles</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="assets/css/design.css">
 </head>

--- a/docs/dist/design/patterns/buttons.html
+++ b/docs/dist/design/patterns/buttons.html
@@ -5,11 +5,11 @@
     <title>Buttons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="UI Structure" href="index.html">
     <link rel="prefetch" title="Navigation Items" href="nav.html">

--- a/docs/dist/design/patterns/emails.html
+++ b/docs/dist/design/patterns/emails.html
@@ -5,11 +5,11 @@
     <title>Emails</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="UI Structure" href="index.html">
     <link rel="prefetch" title="Navigation Items" href="nav.html">

--- a/docs/dist/design/patterns/fullpage.html
+++ b/docs/dist/design/patterns/fullpage.html
@@ -5,11 +5,11 @@
     <title>Full page apps</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="prefetch" title="UI Structure" href="index.html">
     <link rel="prefetch" title="Navigation Items" href="nav.html">

--- a/docs/dist/design/patterns/index.html
+++ b/docs/dist/design/patterns/index.html
@@ -5,11 +5,11 @@
     <title>Structure</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="../assets/css/design.css">
     <link rel="prefetch" title="UI Structure" href="index.html">

--- a/docs/dist/design/patterns/nav.html
+++ b/docs/dist/design/patterns/nav.html
@@ -5,11 +5,11 @@
     <title>Navigation Items</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="../assets/css/design.css">
     <link rel="prefetch" title="UI Structure" href="index.html">

--- a/docs/dist/design/patterns/pickers.html
+++ b/docs/dist/design/patterns/pickers.html
@@ -5,11 +5,11 @@
     <title>Option Lists and Pickers</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="../assets/css/design.css">
     <link rel="prefetch" title="UI Structure" href="index.html">

--- a/docs/dist/design/patterns/switches.html
+++ b/docs/dist/design/patterns/switches.html
@@ -5,11 +5,11 @@
     <title>Switches</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="../assets/css/design.css">
     <link rel="prefetch" title="UI Structure" href="index.html">

--- a/docs/dist/design/patterns/tables.html
+++ b/docs/dist/design/patterns/tables.html
@@ -5,11 +5,11 @@
     <title>Tables</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="stylesheet" href="../assets/css/design.css">
     <link rel="prefetch" title="UI Structure" href="index.html">

--- a/docs/dist/development/rootpanels/index.html
+++ b/docs/dist/development/rootpanels/index.html
@@ -5,11 +5,11 @@
     <title>Root Panels</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/getstarted/index.html
+++ b/docs/dist/getstarted/index.html
@@ -5,11 +5,11 @@
     <title>Get Started</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <script>
         new gui.Request('/dist/sri.json').get().then(function(status, json) {

--- a/docs/dist/getstarted/layout/index.html
+++ b/docs/dist/getstarted/layout/index.html
@@ -5,11 +5,11 @@
     <title>Layout</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/getstarted/rules/index.html
+++ b/docs/dist/getstarted/rules/index.html
@@ -5,11 +5,11 @@
     <title>Basic rules</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/getstarted/usage/index.html
+++ b/docs/dist/getstarted/usage/index.html
@@ -5,11 +5,11 @@
     <title>Usage</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/index.html
+++ b/docs/dist/index.html
@@ -5,11 +5,11 @@
     <title>Tradeshift UI</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
     <script src="/dist/assets/lunr.min.js"></script>

--- a/docs/dist/intro/index.html
+++ b/docs/dist/intro/index.html
@@ -5,11 +5,11 @@
     <title>Tradeshift UI</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
 </head>
 

--- a/docs/dist/screenshots/index.html
+++ b/docs/dist/screenshots/index.html
@@ -5,11 +5,11 @@
     <title>Screenshots</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <link rel="stylesheet" href="index.css">

--- a/docs/dist/screenshots/pages/asides.html
+++ b/docs/dist/screenshots/pages/asides.html
@@ -5,11 +5,11 @@
     <title>Aside</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <script src="asides.js"></script>

--- a/docs/dist/screenshots/pages/bars.html
+++ b/docs/dist/screenshots/pages/bars.html
@@ -5,11 +5,11 @@
     <title>Bars</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <script src="bars.js"></script>

--- a/docs/dist/screenshots/pages/buttons.html
+++ b/docs/dist/screenshots/pages/buttons.html
@@ -5,11 +5,11 @@
     <title>Buttons</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <link rel="stylesheet" href="buttons.css">

--- a/docs/dist/screenshots/pages/forms.html
+++ b/docs/dist/screenshots/pages/forms.html
@@ -5,11 +5,11 @@
     <title>Form</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <script src="forms.js"></script>

--- a/docs/dist/screenshots/pages/index.html
+++ b/docs/dist/screenshots/pages/index.html
@@ -5,11 +5,11 @@
     <title>Screenshot Pages</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
 </head>

--- a/docs/dist/screenshots/pages/panels.html
+++ b/docs/dist/screenshots/pages/panels.html
@@ -5,11 +5,11 @@
     <title>Screenshots</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <meta name="robots" content="noindex">
     <script>

--- a/docs/dist/search/index.html
+++ b/docs/dist/search/index.html
@@ -5,11 +5,11 @@
     <title>Search</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+    <script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
     <script src="/dist/assets/dox.min.js"></script>
     <script src="/dist/assets/mark.min.js"></script>
     <script src="/dist/assets/jquery-2.2.4.min.js"></script>
-    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css">
+    <link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css">
     <link rel="stylesheet" href="/dist/assets/dox.css">
     <script src="/dist/assets/lunr.min.js"></script>
     <script src="index.js"></script>

--- a/docs/dist/sri.json
+++ b/docs/dist/sri.json
@@ -1,16 +1,16 @@
 {
   "@js": {
     "hashes": {
-      "sha384": "mBCfKVgiYzOKrXdPgfOmE6pyMmKsRrTI1BFfGGD6xL3snHxNX2O4ctz4Le30oyhT"
+      "sha384": "Fh3C0y0v+xUvQcYpDfACjK5Py8b1oa/n/j2Y+CnfUfA/W/0uT/fyhpJ++xXiJf9c"
     },
-    "integrity": "sha384-mBCfKVgiYzOKrXdPgfOmE6pyMmKsRrTI1BFfGGD6xL3snHxNX2O4ctz4Le30oyhT",
-    "path": "public/ts-10.0.23.min.js"
+    "integrity": "sha384-Fh3C0y0v+xUvQcYpDfACjK5Py8b1oa/n/j2Y+CnfUfA/W/0uT/fyhpJ++xXiJf9c",
+    "path": "public/ts-10.0.24.min.js"
   },
   "@css": {
     "hashes": {
       "sha384": "ADVBXsEDpMrlyCl0JjT3PNVTFHO8E+oo/nc0nnB7ljMAmGtLvXvf8zqFRyLqkyCL"
     },
     "integrity": "sha384-ADVBXsEDpMrlyCl0JjT3PNVTFHO8E+oo/nc0nnB7ljMAmGtLvXvf8zqFRyLqkyCL",
-    "path": "public/ts-10.0.23.min.css"
+    "path": "public/ts-10.0.24.min.css"
   }
 }

--- a/docs/dist/sri.json
+++ b/docs/dist/sri.json
@@ -1,16 +1,16 @@
 {
   "@js": {
     "hashes": {
-      "sha384": "t8KYVqpP6WQJhORwTkvj9YiwcUcqi0uAmAtHJWgyUlFBwnO2kK6T0el3ymXYXucx"
+      "sha384": "mBCfKVgiYzOKrXdPgfOmE6pyMmKsRrTI1BFfGGD6xL3snHxNX2O4ctz4Le30oyhT"
     },
-    "integrity": "sha384-t8KYVqpP6WQJhORwTkvj9YiwcUcqi0uAmAtHJWgyUlFBwnO2kK6T0el3ymXYXucx",
+    "integrity": "sha384-mBCfKVgiYzOKrXdPgfOmE6pyMmKsRrTI1BFfGGD6xL3snHxNX2O4ctz4Le30oyhT",
     "path": "public/ts-10.0.23.min.js"
   },
   "@css": {
     "hashes": {
-      "sha384": "qVtE8d9ipWI+Vq7x7ICLUqD7z/nrhud1iocyqNf/rRxMwdXKv/JzAYf3L38ZvSxj"
+      "sha384": "ADVBXsEDpMrlyCl0JjT3PNVTFHO8E+oo/nc0nnB7ljMAmGtLvXvf8zqFRyLqkyCL"
     },
-    "integrity": "sha384-qVtE8d9ipWI+Vq7x7ICLUqD7z/nrhud1iocyqNf/rRxMwdXKv/JzAYf3L38ZvSxj",
+    "integrity": "sha384-ADVBXsEDpMrlyCl0JjT3PNVTFHO8E+oo/nc0nnB7ljMAmGtLvXvf8zqFRyLqkyCL",
     "path": "public/ts-10.0.23.min.css"
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,11 +6,11 @@
 		<script src="/dist/assets/lunr.min.js"></script>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width"/>
-		<script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.js"></script>
+		<script src="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.js"></script>
 		<script src="/dist/assets/dox.min.js"></script>
 		<script src="/dist/assets/mark.min.js"></script>
 		<script src="/dist/assets/jquery-2.2.4.min.js"></script>
-		<link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.23.min.css"/>
+		<link rel="stylesheet" href="//d5wfroyti11sa.cloudfront.net/prod/client/ts-10.0.24.min.css"/>
 		<link rel="stylesheet" href="/dist/assets/dox.css"/>
 		<link rel="robots" href="/dist/intro/"/>
 		<link rel="robots" href="/dist/getstarted/"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tradeshift-ui",
-	"version": "10.0.23",
+	"version": "10.0.24",
 	"private": true,
 	"description": "The Tradeshift UI Library & Framework",
 	"homepage": "https://ui.tradeshift.com/",

--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.SwitchSpirit.OLDVERSION.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.SwitchSpirit.OLDVERSION.js
@@ -1,5 +1,5 @@
 /**
- * REVISION OF THE SWITCH FOR ANGULAR 1.5, SEEMS IT BREAKS IN ANGULAR 1.3 THOUGH
+ * Spirit of the switch.
  * TODO (jmo@): Support swipe gestures on that switch!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * @extends {ts.ui.FieldSpirit}
  * @using {string} tick
@@ -16,23 +16,27 @@ ts.ui.SwitchSpirit = (function using(tick, time) {
 		},
 
 		/**
-		 * Attaching to the DOM.
+		 * Attach to the DOM.
 		 */
 		onattach: function() {
 			this.super.onattach();
 			this.event.add('change');
-			this._createswitch();
+			this.css.add([
+				// TODO: update these classnames what with the new stylee!
+				ts.ui.CLASS_SWITCHBOX,
+				ts.ui.CLASS_ENGINE
+			]);
+			this._switch = this._createswitch();
 			this._synchronize(true);
-			this.tick.add(tick).start(tick, time);
-			this.css.add([ts.ui.CLASS_SWITCHBOX, ts.ui.CLASS_ENGINE]);
 		},
 
 		/**
-		 * Detaching from the DOM.
+		 * Syncrhonize on an interval so that we don't have to anticipate
+		 * all the strange stuff that Angular might do with our elements.
 		 */
-		ondetach: function() {
-			this.super.ondetach();
-			this.tick.remove(tick);
+		onready: function() {
+			this.super.onready();
+			this.tick.add(tick).start(tick, time);
 		},
 
 		/**
@@ -77,34 +81,27 @@ ts.ui.SwitchSpirit = (function using(tick, time) {
 		// Private .................................................................
 
 		/**
+		 * The switch DHTML thing.
+		 * @type {HTMLDivElement}
+		 */
+		_switch: null,
+
+		/**
 		 * Snapshot checked status so that we know when it changes.
 		 * @type {boolean|null}
 		 */
 		_snapshot: null,
 
 		/**
-		 * Fetch the switch element (and potentially create it).
-		 * @param {boolean} [create] - Create switch if it doesn't exist?
-		 * @returns {HTMLDivElement}
-		 */
-		_switch: function(create) {
-			if (create && !this._switch()) {
-				return this._createswitch();
-			} else {
-				var elm = this.dom.following(ts.ui.Spirit)[0];
-				return elm && elm.css.contains('ts-switcher') ? elm : null;
-			}
-		},
-
-		/**
-		 * Inject the switch. Let's remove any potential existing 
-		 * switch, accounting for strange Angular quantum effects.
+		 * Inject the switch while accounting for strange Angular quantum effects.
 		 * @returns {ts.ui.Spirit}
 		 */
 		_createswitch: function() {
-			var html = ts.ui.switchonly.edbml();
-			this._switch() ? this._switch().dom.remove() : void 0;
-			return ts.ui.get(this.dom.after(this.dom.parseToNode(html)));
+			var oldswitch = this.dom.following(ts.ui.Spirit)[0];
+			if (oldswitch && oldswitch.css.contains('ts-switcher')) {
+				oldswitch.dom.remove();
+			}
+			return ts.ui.get(this.dom.after(this.dom.parseToNode(ts.ui.switchonly.edbml())));
 		},
 
 		/**
@@ -115,7 +112,7 @@ ts.ui.SwitchSpirit = (function using(tick, time) {
 		_synchronize: function(init) {
 			var checked = this.element.checked;
 			if (init || checked !== this._snapshot) {
-				this._switch(true).css.shift(checked, ts.ui.CLASS_CHECKED);
+				this._switch.css.shift(checked, ts.ui.CLASS_CHECKED);
 				this._snapshot = checked;
 				if (!init) {
 					this.action.dispatch(ts.ui.ACTION_SWITCH, checked);

--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.SwitchSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.SwitchSpirit.js
@@ -1,5 +1,5 @@
 /**
- * Spirit of the switch.
+ * REVISION OF THE SWITCH FOR ANGULAR 1.5, SEEMS IT BREAKS IN ANGULAR 1.3 THOUGH
  * TODO (jmo@): Support swipe gestures on that switch!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * @extends {ts.ui.FieldSpirit}
  * @using {string} tick
@@ -16,27 +16,23 @@ ts.ui.SwitchSpirit = (function using(tick, time) {
 		},
 
 		/**
-		 * Attach to the DOM.
+		 * Attaching to the DOM.
 		 */
 		onattach: function() {
 			this.super.onattach();
 			this.event.add('change');
-			this.css.add([
-				// TODO: update these classnames what with the new stylee!
-				ts.ui.CLASS_SWITCHBOX,
-				ts.ui.CLASS_ENGINE
-			]);
-			this._switch = this._createswitch();
+			this._createswitch();
 			this._synchronize(true);
+			this.tick.add(tick).start(tick, time);
+			this.css.add([ts.ui.CLASS_SWITCHBOX, ts.ui.CLASS_ENGINE]);
 		},
 
 		/**
-		 * Syncrhonize on an interval so that we don't have to anticipate
-		 * all the strange stuff that Angular might do with our elements.
+		 * Detaching from the DOM.
 		 */
-		onready: function() {
-			this.super.onready();
-			this.tick.add(tick).start(tick, time);
+		ondetach: function() {
+			this.super.ondetach();
+			this.tick.remove(tick);
 		},
 
 		/**
@@ -81,27 +77,34 @@ ts.ui.SwitchSpirit = (function using(tick, time) {
 		// Private .................................................................
 
 		/**
-		 * The switch DHTML thing.
-		 * @type {HTMLDivElement}
-		 */
-		_switch: null,
-
-		/**
 		 * Snapshot checked status so that we know when it changes.
 		 * @type {boolean|null}
 		 */
 		_snapshot: null,
 
 		/**
-		 * Inject the switch while accounting for strange Angular quantum effects.
+		 * Fetch the switch element (and potentially create it).
+		 * @param {boolean} [create] - Create switch if it doesn't exist?
+		 * @returns {HTMLDivElement}
+		 */
+		_switch: function(create) {
+			if (create && !this._switch()) {
+				return this._createswitch();
+			} else {
+				var elm = this.dom.following(ts.ui.Spirit)[0];
+				return elm && elm.css.contains('ts-switcher') ? elm : null;
+			}
+		},
+
+		/**
+		 * Inject the switch. Let's remove any potential existing 
+		 * switch, accounting for strange Angular quantum effects.
 		 * @returns {ts.ui.Spirit}
 		 */
 		_createswitch: function() {
-			var oldswitch = this.dom.following(ts.ui.Spirit)[0];
-			if (oldswitch && oldswitch.css.contains('ts-switcher')) {
-				oldswitch.dom.remove();
-			}
-			return ts.ui.get(this.dom.after(this.dom.parseToNode(ts.ui.switchonly.edbml())));
+			var html = ts.ui.switchonly.edbml();
+			this._switch() ? this._switch().dom.remove() : void 0;
+			return ts.ui.get(this.dom.after(this.dom.parseToNode(html)));
 		},
 
 		/**
@@ -112,7 +115,7 @@ ts.ui.SwitchSpirit = (function using(tick, time) {
 		_synchronize: function(init) {
 			var checked = this.element.checked;
 			if (init || checked !== this._snapshot) {
-				this._switch.css.shift(checked, ts.ui.CLASS_CHECKED);
+				this._switch(true).css.shift(checked, ts.ui.CLASS_CHECKED);
 				this._snapshot = checked;
 				if (!init) {
 					this.action.dispatch(ts.ui.ACTION_SWITCH, checked);


### PR DESCRIPTION
Just to make sure that the branch doesn't get lost (again), this would update the Switch to work in Angular 1.5. We'll need to confirm that it doesn't break the Switch in Angular 1.3, of course, but here it is. This fix has been released in version `10.0.24` (but not merged to V4).