### PR TITLE
Remove inline event listeners to support CSP environment

### DIFF
--- a/docs/src/xhtml/components/asides/index.xhtml
+++ b/docs/src/xhtml/components/asides/index.xhtml
@@ -223,6 +223,12 @@
 							</aside>
 						</script>
 					</figure>
+
+					<div data-ts="Note">
+						<i class="ts-icon-warning"></i>
+						<p>The inline event listeners as shown above above will simply not work with any sensible <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP" target="_blank">Content Security Policy</a> enabled. Use <a data-ts="Button" href="/#components/asides/js.html">DOM event listeners</a> instead.</p>
+					</div>
+
 				</section>
 
 				<h3>Stacking Asides</h3>

--- a/docs/src/xhtml/components/bars/topbar.xhtml
+++ b/docs/src/xhtml/components/bars/topbar.xhtml
@@ -76,8 +76,9 @@
 					<figure data-ts="DoxScript">
 						<script type="runnable">
 							var tabs = ts.ui.TopBar.tabs();
-							tabs[4].label = 'Choose Me!';
-							tabs[4].onselect = function() {
+							var last = tabs.length - 1;
+							tabs[last].label = 'Choose Me!';
+							tabs[last].onselect = function() {
 								this.label = 'Thanks!';
 							};
 						</script>

--- a/docs/src/xhtml/components/footer/actions.xhtml
+++ b/docs/src/xhtml/components/footer/actions.xhtml
@@ -152,7 +152,10 @@
 						</script>
 					</figure>
 					
-					<p>You must manually toggle the <code>checked</code> property. This will give you a chance to let the user confirm if he really intends to select millions of products; or if he really wants to clear a selection that took him hours to complete. Here is the <code>CheckBoxModel</code>.</p>
+					<p>You must manually toggle the <code>checked</code> property. This will give you a chance to let the user confirm if he really intends to select millions of products; or if he really wants to clear a selection that took him hours to complete.</p>
+
+					<!-- TODO: Table with checkbox API goes here! -->
+
 					<p>Use the <code>indeterminate</code> property if state that is neither checked nor unchecked. It's a in-between state that can be used show a partial selection and to check all selections.</p>
 
 					<figure data-ts="DoxScript">

--- a/docs/src/xhtml/components/modals/index.xhtml
+++ b/docs/src/xhtml/components/modals/index.xhtml
@@ -234,6 +234,10 @@
 							</dialog>
 						</script>
 					</figure>
+					<div data-ts="Note">
+						<i class="ts-icon-warning"></i>
+						<p>The inline event listeners as shown above will simply not work with any sensible <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP" target="_blank">Content Security Policy</a> enabled. Use instead aforementioned JavaScript API.</p>
+					</div>
 					<p>Finally, you can also track the state with some custom DOM events if you like.</p>
 					<figure data-ts="DoxScript">
 						<script>

--- a/docs/src/xhtml/components/pager/index.xhtml
+++ b/docs/src/xhtml/components/pager/index.xhtml
@@ -23,6 +23,10 @@
 						</script>
 						<output/>
 					</figure>
+					<div data-ts="Note">
+						<i class="ts-icon-warning"></i>
+						<p>The inline event listener <code>onselect</code> as shown above will simply not work with any sensible <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP" target="_blank">Content Security Policy</a> enabled. Refer to the JavaScript API below.</p>
+					</div>
 					<p>&mdash; or you can configure it via a JavaScript API, like in this example.</p>
 					<figure data-ts="DoxScript">
 						<script type="runnable">

--- a/spec/jasmine/index.html
+++ b/spec/jasmine/index.html
@@ -2,6 +2,12 @@
 <html lang="zh-CN">
 	<head>
 		<meta charset="UTF-8"/>
+		<meta http-equiv="Content-Security-Policy" content="
+			default-src 'self';
+			style-src 'self' 'unsafe-inline';
+			font-src 'self' data:;
+ 			img-src 'self' data:;
+		">
 		<title>Jasmine Spec Runner v2.6.4</title>
 		
 		<link rel="shortcut icon" type="image/png" href="jasmine-2.6.4/jasmine_favicon.png"/>

--- a/src/spiritual/spiritual-edbml/edbml@wunderbyte.com/render/edbml.UpdateManager.js
+++ b/src/spiritual/spiritual-edbml/edbml@wunderbyte.com/render/edbml.UpdateManager.js
@@ -36,21 +36,17 @@ edbml.UpdateManager = (function using(
 		 */
 		update: function(html) {
 			if (!this._spirit.life.destructed) {
-				this._updates = new UpdateCollector();
+				var updates = (this._updates = new UpdateCollector());
 				this._functions = {};
-				if (!this._olddom) {
-					this._first(html);
-				} else {
-					this._next(html);
-					this._updates.collect(new FunctionUpdate(this._keyid, this._functions));
-				}
-				this._updates.eachRelevant(function(update) {
+				this._olddom ? this._next(html) : this._first(html);
+				updates.collect(new FunctionUpdate(this._keyid, this._functions));
+				updates.eachRelevant(function(update) {
 					update.update();
 					update.dispose();
 				});
 				if (this._updates) {
 					// huh? how can it be null?
-					this._updates.dispose();
+					updates.dispose();
 				}
 				this._updates = null;
 			}
@@ -304,9 +300,10 @@ edbml.UpdateManager = (function using(
 		 * @returns {boolean}
 		 */
 		_onlyedbmlchange: function(newval, oldval) {
+			var functions = this._functions;
 			if (
 				[newval, oldval].every(function(val) {
-					return val.includes('edbml.$');
+					return gui.KeyMaster.isKey(val) || val.includes('edbml.$');
 				})
 			) {
 				var newkey;
@@ -317,8 +314,8 @@ edbml.UpdateManager = (function using(
 						newkey = newkeys[i];
 						newval = newval.replace(newkey, '');
 						oldval = oldval.replace(oldkey, '');
-						this._functions[oldkey] = newkey;
-					}, this);
+						functions[oldkey] = newkey;
+					});
 					return newval === oldval;
 				}
 			}

--- a/src/spiritual/spiritual-edbml/edbml@wunderbyte.com/render/updates/functions/edbml.FunctionUpdate.js
+++ b/src/spiritual/spiritual-edbml/edbml@wunderbyte.com/render/updates/functions/edbml.FunctionUpdate.js
@@ -2,130 +2,174 @@
  * Updating the functions it is.
  * TODO: revoke all functions from destructed spirit (unless window.unload)
  */
-edbml.FunctionUpdate = edbml.Update.extend(
-	{
-		/**
-		 * Update type.
-		 * @type {String}
-		 */
-		type: edbml.Update.TYPE_FUNCTION,
-
-		/**
-		 * Setup update.
-		 * @param {String} id
-		 * @param @optional {Map<String,String>} map
-		 */
-		onconstruct: function(id, map) {
-			this.super.onconstruct();
-			this.id = id;
-			this._map = map || null;
-		},
-
-		/**
-		 * Do the update.
-		 */
-		update: function() {
-			var count = 0;
-			this.element(function(elm) {
-				if (this._map) {
-					if ((count = edbml.FunctionUpdate._remap(elm, this._map))) {
-						this._report('remapped ' + count + ' keys');
+edbml.FunctionUpdate = (function() {
+	/**
+	 * Convert `data-onclick` attribute into an `onclick` event listener.
+	 * @param {Element} elm
+	 * @param {Attribute} att
+	 * @param {string} key
+	 */
+	function setup(elm, att, key) {
+		if (ispoke(att)) {
+			elm[att.name.split('data-')[1]] = key
+				? function() {
+						edbml.$run(this, key);
 					}
-				} else {
-					if ((count = edbml.FunctionUpdate._revoke(elm))) {
-						this._report('revoked ' + count + ' keys');
-					}
-				}
-			});
-		},
-
-		// Private ...................................................................
-
-		/**
-		 * Report the update.
-		 * @param {String} report
-		 */
-		_report: function(report) {
-			var message = 'edbml.FunctionUpdate ' + report + ' (' + this.$instanceid + ')';
-			this.super._report(message);
+				: null;
 		}
-	},
-	{
-		// Static .................................................................
+	}
 
-		/**
-		 * @param {Element} element
-		 */
-		_revoke: function(element) {
-			var att,
-				count = 0,
-				keys;
-			this._getatts(element).forEach(function(x) {
-				att = x[1];
-				keys = gui.KeyMaster.extractKey(att.value);
-				if (keys) {
-					keys.forEach(function(key) {
-						edbml.$revoke(key);
-						count++;
-					});
-				}
-			});
-			return count;
+	/**
+	 * @param {Attribute} att
+	 * @returns {boolean}
+	 */
+	function ispeek(att) {
+		return att.name.startsWith('data-ts.') && gui.KeyMaster.isKey(att.value);
+	}
+
+	/**
+	 * @param {Attribute} att
+	 * @returns {boolean}
+	 */
+	function ispoke(att) {
+		return att.name.startsWith('data-on');
+	}
+
+	return edbml.Update.extend(
+		{
+			/**
+			 * Update type.
+			 * @type {String}
+			 */
+			type: edbml.Update.TYPE_FUNCTION,
+
+			/**
+			 * Setup update.
+			 * @param {String} id
+			 * @param @optional {Map<String,String>} map
+			 */
+			onconstruct: function(id, map) {
+				this.super.onconstruct();
+				this.id = id;
+				this._map = map || null;
+			},
+
+			/**
+			 * Do the update.
+			 */
+			update: function() {
+				var count = 0;
+				this.element(function(elm) {
+					if (this._map) {
+						if ((count = edbml.FunctionUpdate._remap(elm, this._map))) {
+							this._report('remapped ' + count + ' keys');
+						}
+					} else {
+						if ((count = edbml.FunctionUpdate._revoke(elm))) {
+							this._report('revoked ' + count + ' keys');
+						}
+					}
+				});
+			},
+
+			// Private ...................................................................
+
+			/**
+			 * Report the update.
+			 * @param {String} report
+			 */
+			_report: function(report) {
+				var message = 'edbml.FunctionUpdate ' + report + ' (' + this.$instanceid + ')';
+				this.super._report(message);
+			}
 		},
+		{
+			// Static .................................................................
 
-		/**
-		 * @param {Element} element
-		 * @param {Map<String,String>} map
-		 */
-		_remap: function(element, map) {
-			var count = 0,
-				oldkeys,
-				newkey,
-				newval;
-			if (Object.keys(map).length) {
+			/**
+			 * @param {Element} element
+				 */
+			_revoke: function(element) {
+				var att,
+					elm,
+					count = 0,
+					keys;
+				this._getatts(element).forEach(function(x) {
+					elm = x[0];
+					att = x[1];
+					keys = gui.KeyMaster.extractKey(att.value);
+					if (keys) {
+						keys.forEach(function(key) {
+							setup(elm, att, null);
+							edbml.$revoke(key);
+							count++;
+						});
+					}
+				});
+				return count;
+			},
+
+			/**
+			 * @param {Element} element
+			 * @param {Map<String,String>} map
+			 */
+			_remap: function(element, map) {
+				var count = 0,
+					oldkeys;
 				this._getatts(element).forEach(function(x) {
 					var elm = x[0];
 					var att = x[1];
 					if ((oldkeys = gui.KeyMaster.extractKey(att.value))) {
 						oldkeys.forEach(function(oldkey) {
-							if ((newkey = map[oldkey])) {
-								newval = att.value.replace(oldkey, newkey);
-								elm.setAttribute(att.name, newval);
+							var newkey = map[oldkey];
+							if (newkey) {
+								elm.setAttribute(att.name, newkey);
+								setup(elm, att, newkey);
 								edbml.$revoke(oldkey);
 								count++;
+							} else {
+								setup(elm, att, oldkey);
 							}
 						});
 					}
 				});
-			}
-			return count;
-		},
+				return count;
+			},
 
-		/**
-		 * Collect attributes from DOM subtree that
-		 * somewhat resemble EDBML poke statements.
-		 * @returns {Array<Array<Node>>}
-		 */
-		_getatts: function(element) {
-			var val,
-				atts = [];
-			new gui.Crawler('edbml-crawler-functionupdate').descend(element, {
-				handleElement: function(elm) {
-					if (elm !== element) {
-						Array.forEach(elm.attributes, function(att) {
-							val = att.value;
-							if (val.includes('edbml.$run') || val.includes('edbml.$get')) {
-								atts.push([elm, att]);
+			/**
+			 * Collect attributes from DOM subtree that
+			 * somewhat resemble EDBML poke statements.
+			 * @returns {Array<Array<Node>>}
+			 */
+			_getatts: function(element) {
+				var atts = [];
+				new gui.Crawler('edbml-crawler-functionupdate').descend(element, {
+					handleElement: function(elm) {
+						if (elm !== element) {
+							Array.forEach(elm.attributes, function(att) {
+								/*
+								if(att.value.includes('edbml.$get')) {
+									console.error('TODO', att.value);
+								}
+								val = att.value;
+								if (val.includes('edbml.$run') || val.includes('edbml.$get')) {
+									atts.push([elm, att]);
+								}
+								*/
+
+								if (ispeek(att) || ispoke(att)) {
+									atts.push([elm, att]);
+								}
+							});
+							if (elm.spirit && elm.spirit.script.loaded) {
+								// ... not our DOM tree
+								return gui.Crawler.SKIP_CHILDREN;
 							}
-						});
-						if (elm.spirit && elm.spirit.script.loaded) {
-							// ... not our DOM tree
-							return gui.Crawler.SKIP_CHILDREN;
 						}
 					}
-				}
-			});
-			return atts;
+				});
+				return atts;
+			}
 		}
-	}
-);
+	);
+})();

--- a/src/spiritual/spiritual-edbml/edbml@wunderbyte.com/runtime/edbml.Out.js
+++ b/src/spiritual/spiritual-edbml/edbml@wunderbyte.com/runtime/edbml.Out.js
@@ -1,30 +1,50 @@
 /**
- * Collects HTML output during EDBML rendering phase.
- * Any methods added to this prototype will become
- * available in EDBML scripts as: out.mymethod()
+ * @param {RegExp} PEEK - match expression to read variable declared in EDBML
+ * @param {RegExp} POKE - match expression to execute function declared in EDBML
  */
-edbml.Out = function Out() {};
-
-edbml.Out.prototype = {
+(function scoped(PEEK, POKE) {
 	/**
-	 * HTML string (not well-formed while parsing).
-	 * @type {String}
+	 * Replace inline event listeners with CSP-safe attributes. These attributes 
+	 * must later be converted to real event listeners by an external mechanism.
+	 * TODO: Perhaps move this change into the dependency `grunt-spiritual-edbml`
+	 * @param {string} html
+	 * @returns {string}
 	 */
-	html: '',
-
-	/**
-	 * Identification.
-	 * @returns {String}
-	 */
-	toString: function() {
-		return '[object edbml.Out]';
-	},
-
-	/**
-	 * Get HTML result (output override scenario).
-	 * @returns {String}
-	 */
-	write: function() {
-		return this.html;
+	function contentSecured(html) {
+		return html.replace(PEEK, '$1="$2"').replace(POKE, 'data-$1="$2"');
 	}
-};
+
+	/**
+	 * Collects HTML output during EDBML rendering phase.
+	 * Any methods added to this prototype will become
+	 * available in EDBML scripts as: out.mymethod()
+	 */
+	edbml.Out = function Out() {};
+
+	edbml.Out.prototype = {
+		/**
+		 * HTML string (not well-formed while parsing).
+		 * @type {String}
+		 */
+		html: '',
+
+		/**
+		 * Identification.
+		 * @returns {String}
+		 */
+		toString: function() {
+			return '[object edbml.Out]';
+		},
+
+		/**
+		 * Get HTML result (output override scenario).
+		 * @returns {String}
+		 */
+		write: function() {
+			return contentSecured(this.html);
+		}
+	};
+})(
+	/(data-ts\.[_$a-z0-9]*)="edbml\.\$get\(\&quot;(key\d+)\&quot;\);"/g,
+	/(on[a-z]*)="edbml\.\$run\(this, '(key\d*)'\);"/g
+);

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/plugins/config/gui.ConfigPlugin.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/plugins/config/gui.ConfigPlugin.js
@@ -75,7 +75,8 @@ gui.ConfigPlugin = gui.Plugin.extend(
 		 * @param {string} dot
 		 */
 		_evaluate: function(name, value, fix, dot) {
-			var struct = this.spirit,
+			var originame = name,
+				struct = this.spirit,
 				success = true,
 				prop = null,
 				cuts = null;
@@ -96,7 +97,7 @@ gui.ConfigPlugin = gui.Plugin.extend(
 			}
 			// Note that a "getter" must not returned `undefined` here!
 			if (success && gui.Type.isDefined(struct[prop])) {
-				this._schedule(struct, prop, this._revaluate(value));
+				this._schedule(struct, prop, this._revaluate(value, originame));
 			} else {
 				console.error('No definition for "' + name + '" in ' + this.spirit.toString());
 			}
@@ -141,9 +142,9 @@ gui.ConfigPlugin = gui.Plugin.extend(
 		 * @param {object} value
 		 * @returns {object}
 		 */
-		_revaluate: function(value) {
+		_revaluate: function(value, name) {
 			if (gui.Type.isString(value)) {
-				if (gui.hasModule('edbml@wunderbyte.com') && value.startsWith('edbml.$get')) {
+				if (this._ispoke(value, name)) {
 					value = window.edbml.$get(gui.KeyMaster.extractKey(value)[0]);
 				} else {
 					value = gui.Type.cast(value);
@@ -153,6 +154,19 @@ gui.ConfigPlugin = gui.Plugin.extend(
 				}
 			}
 			return value;
+		},
+
+		/**
+		 * @param {*} value
+		 * @param {string} name
+		 * @returns {boolean}
+		 */
+		_ispoke: function(value, name) {
+			return (
+				gui.hasModule('edbml@wunderbyte.com') &&
+				name.startsWith('data-ts.') &&
+				gui.KeyMaster.isKey(value)
+			);
 		}
 	},
 	{
@@ -172,14 +186,35 @@ gui.ConfigPlugin = gui.Plugin.extend(
 		SEPARATOR: '.',
 
 		/**
-		 * Hack to parse invalid JSON (with no quotes on keys)
-		 * as valid JSON, so basically a relaxed `JSON.parse`.
-		 * TODO: Now validate that we actually get an object!
+		 * Parse JSON accounting for potentially invalid JSON with no quotes on keys.
+		 * We'll attempt to assume valid JSON first, just in case that regexp is bad.
 		 * @param {string} json
 		 * @returns {object}
 		 */
-		jsonify: (function(div) {
-			return function(json) {
+		jsonify: function(json) {
+			var UNQUOTED = /(['"])?([a-zA-Z0-9_\$]+)(['"])?\s*:/g;
+			try {
+				return JSON.parse(json);
+			} catch (x1) {
+				try {
+					json = json.replace(UNQUOTED, '"$2":');
+					return JSON.parse(json);
+				} catch (x2) {
+					console.error(x2);
+					console.warn(json);
+				}
+			}
+		},
+
+		/**
+		 * @deprecated
+		 * This doesn't work with proper CSP settings, but it 
+		 * should always be remembered as the better hack.
+ 		 * @param {string} json
+ 		 * @returns {object}
+ 		 */
+		deprecated_jsonify: (function(div) {
+			return function UNSAFE_HACK(json) {
 				div.setAttribute('onclick', 'this.json = ' + json);
 				div.click();
 				return div.json;


### PR DESCRIPTION
@zdlm @sampi @ehats 

The minimum viable amount of quickfixes that at least in theory should make it possible to enable a (fairly liberal) Content Security Policy on the entire platform. We have been a blocker for getting this project off the ground, since Tradeshift UI runs on all pages.

There was also some random fixes to the docs pages.

Our target CSP aims to disable all inline JavaScript and this means that it is not enough to fix the framework (with this proposed PR). For use on the platform, it will also be required to update the implementation in all the apps so that this:

```html
<aside data-ts="Aside" data-ts.onclose="alert('closed')">
```
— becomes replaced by this:
```js
ts.ui.get('#myaside', aside => aside.onclose = () => alert('closed'));
```
— which in other words involves moving the business logic from the HTML view to some kind of JS file :confused: 

Apart from providing a better fit for the Angular or React way of life, where inline event listeners are the norm, it was also thought that inline event listeners would better support a scenario where the elements(s) get destroyed and created at random by the hosting framework. Now that the `onclick` statement is no longer expressed in the HTML, but instead as a method on the DOM element, Angular might in other words replace the active element with an inactive element, simply because that would be typical for Angular to do such a thing. It remains to be seen if this will actually happen in real life smoke tests.