### PR TITLE
[gui.ConfigPlugin] Fix `encodeURIComponent(JSON.stringify(data).trim())`-style attribute parsing on Win7/IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "description": "The Tradeshift UI Library & Framework",
   "homepage": "http://ui.tradeshift.com/",
   "bugs": {
@@ -33,8 +33,7 @@
     "prelease": "release-it --config=.release-it.beta.json --npm.tag=next",
     "****** TEST *****": "",
     "test": "npm run eslint & grunt jasmine & wait && node tasks/browserstack.js",
-    "http":
-      "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}' -a 0.0.0.0",
+    "http": "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}' -a 0.0.0.0",
     "****** NODE *****": "",
     "postinstall": "cd docs && npm ci",
     "precommit": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "prelease": "release-it --config=.release-it.beta.json --npm.tag=next",
     "****** TEST *****": "",
     "test": "npm run eslint & grunt jasmine & wait && node tasks/browserstack.js",
-    "http": "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}'",
+    "http":
+      "static spec/jasmine -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}' -a 0.0.0.0",
     "****** NODE *****": "",
     "postinstall": "cd docs && npm ci",
     "precommit": "lint-staged",

--- a/spec/runtime/spirits/objects-gui@tradeshift.com/ts.ui.CompanyCardSpirit.spec.js
+++ b/spec/runtime/spirits/objects-gui@tradeshift.com/ts.ui.CompanyCardSpirit.spec.js
@@ -42,26 +42,23 @@ describe('ts.ui.CompanyCardSpirit', function likethis() {
 		});
 	});
 
-	// disable flaky test for IE machines...
-	if (!gui.Client.isExplorer && !gui.Client.isEdge) {
-		it('should generate HTML via ts.render="encodedjson"', function(done) {
-			var spirit,
-				dom = helper.createTestDom();
-			var encodedjson = encodeURIComponent(JSON.stringify(CARDDATA).trim());
-			dom.innerHTML = '<div data-ts="CompanyCard" data-ts.render="' + encodedjson + '"></div>';
-			sometime(function later() {
-				spirit = ts.ui.get(dom.querySelector('div'));
-				var html = spirit.element.innerHTML.replace(/&amp;/g, '&');
-				Object.keys(CARDDATA.data).forEach(function(key) {
-					if (key === 'connection') {
-						expect(html).toContain('Connected');
-					} else {
-						var value = CARDDATA.data[key];
-						expect(html).toContain(value);
-					}
-				});
-				done();
+	it('should generate HTML via ts.render="encodedjson"', function(done) {
+		var spirit,
+			dom = helper.createTestDom();
+		var encodedjson = encodeURIComponent(JSON.stringify(CARDDATA).trim());
+		dom.innerHTML = '<div data-ts="CompanyCard" data-ts.render="' + encodedjson + '"></div>';
+		sometime(function later() {
+			spirit = ts.ui.get(dom.querySelector('div'));
+			var html = spirit.element.innerHTML.replace(/&amp;/g, '&');
+			Object.keys(CARDDATA.data).forEach(function(key) {
+				if (key === 'connection') {
+					expect(html).toContain('Connected');
+				} else {
+					var value = CARDDATA.data[key];
+					expect(html).toContain(value);
+				}
 			});
+			done();
 		});
-	}
+	});
 });

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/plugins/config/gui.ConfigPlugin.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/plugins/config/gui.ConfigPlugin.js
@@ -182,6 +182,10 @@ gui.ConfigPlugin = gui.Plugin.extend(
 			return function(json) {
 				div.setAttribute('onclick', 'this.json = ' + json);
 				div.click();
+				// IE11 on Win7 doesn't do anything when calling click()
+				if (div.json === undefined) {
+					div.onclick();
+				}
 				return div.json;
 			};
 		})(document.createElement('div')),


### PR DESCRIPTION
@sampi @zdlm @tynandebold

Fixes issue #667 #499

For some weird reason _only_ on Windows 7, not Win10, in IE11 when we try the lax `JSON.parse()` with the `onclick` hack, `div.click()` doesn't do anything.
> Instead of calling `JSON.parse()` with a try-catch, we set an `onclick` attribute on a newly created `div` to set the DOM object's `this.json` to be the parsed value. We can parse JS-like objects, with functions and unquoted properties.
> > This should probably be examined for security holes.

Now we'll also try to call `div.onclick()` if the results are empty of the call and this seems to be successful on Win7/IE11.
