### PR TITLE
[release-it] --no-merges in changelog

### DIFF
--- a/.release-it.beta.json
+++ b/.release-it.beta.json
@@ -3,7 +3,8 @@
 	"verbose": true,
 	"requireCleanWorkingDir": false,
 	"preRelease": "beta",
-	"changelogCommand": "echo \"### Commits\n$(git log --pretty=format:'* %s (%h)' [REV_RANGE])\"",
+	"changelogCommand":
+		"echo \"### Commits\n$(git log --no-merges --pretty=format:'* %s (%h)' [REV_RANGE])\"",
 	"src": {
 		"commitMessage": "Pre-release v%s",
 		"tagName": "v%s",

--- a/.release-it.json
+++ b/.release-it.json
@@ -2,7 +2,8 @@
 	"non-interactive": true,
 	"verbose": true,
 	"requireCleanWorkingDir": true,
-	"changelogCommand": "echo \"### Commits\n$(git log --pretty=format:'* %s (%h)' [REV_RANGE])\"",
+	"changelogCommand":
+		"echo \"### Commits\n$(git log --no-merges --pretty=format:'* %s (%h)' [REV_RANGE])\"",
 	"src": {
 		"commitMessage": "Release v%s",
 		"tagName": "v%s",


### PR DESCRIPTION
@sampi @zdlm @tynandebold

Skip merge commits from the commit list on GitHub releases.

Stuff like: `Merge branch 'master' into v11/20px-unit-new-colors (bfa531b)` or `Merge pull request #660 from Tradeshift/dsp/gh-pages-improvements (04e6fbc)`