### PR TITLE
[Table] fix issue with incorrect table pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "11.0.2",
+  "version": "11.0.3",
   "description": "The Tradeshift UI Library & Framework",
   "homepage": "http://ui.tradeshift.com/",
   "bugs": {

--- a/src/runtime/js/ts.ui/tables/tables-gui@tradeshift.com/spirits/ts.ui.TableSpirit.js
+++ b/src/runtime/js/ts.ui/tables/tables-gui@tradeshift.com/spirits/ts.ui.TableSpirit.js
@@ -1672,6 +1672,12 @@ ts.ui.TableSpirit = (function using(
 					this._resizing = true;
 					this.script.suspend();
 					this._bestpage(index);
+				} else {
+					var model = this._model;
+					var pager = this.pager();
+					if (this._ownpager && model.maxrows) {
+						pager.pages = model.pageCount();
+					}
 				}
 			}
 			this._maybecallresize();


### PR DESCRIPTION
@sampi @zdlm @tynandebold

Closes issue #602 

The table component was often incorrectly calculating the number of pages needed to display all of data. For example, if there was 55 rows in total, the table would only show four pages of data, with 11 rows per page. You wouldn't be able to view rows 45 and above. This fixes that problem. 
