### PR TITLE
Fix typo

### DIFF
--- a/docs/src/xhtml/getstarted/index.xhtml
+++ b/docs/src/xhtml/getstarted/index.xhtml
@@ -46,7 +46,7 @@
 						</script>
 					</figure>
 					-->
-					<p>UI components are initialized on the <code>DOMContentLoaded</code> event, but this might change some day. To make sure that all the components are initialized before you do something to them, you can wrap you code in a callback like this.</p>
+					<p>UI components are initialized on the <code>DOMContentLoaded</code> event, but this might change some day. To make sure that all the components are initialized before you do something to them, you can wrap your code in a callback like this.</p>
 					<figure data-ts="DoxScript">
 						<script>
 							ts.ui.ready(function() {


### PR DESCRIPTION
@sampi @zdlm @tynandebold

Fixing a typo in the `Get started` page of the documentation site
