### PR TITLE
chrore(grunt): added __mocks__ folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
 		.merge('config.json', 'config.local.json');
 
 	/**
-	 * Supported language codes. This will become populated 
+	 * Supported language codes. This will become populated
 	 * as soon as we trawl the files in the `lang` folder.
 	 * @type {Set<String>}
 	 */
@@ -110,6 +110,10 @@ module.exports = function(grunt) {
 					{
 						src: 'README.md',
 						dest: 'dist/npm/README.md'
+					},
+					{
+						src: 'src/__mocks__/ts.js',
+						dest: 'dist/npm/__mocks__/ts.js'
 					}
 				]
 			}
@@ -686,7 +690,7 @@ module.exports = function(grunt) {
 	}
 
 	/**
-	 * Transform JS inside some file into a `case` inside a `switch` statement 
+	 * Transform JS inside some file into a `case` inside a `switch` statement
 	 * whilst at the same time compiling the list of supported language codes.
 	 * @param {Set<string>} codes
 	 * @returns {Function}
@@ -707,10 +711,10 @@ module.exports = function(grunt) {
 	}
 
 	/**
-	 * Moment.js has been copy-pasted from the internet with *all* the possible 
-	 * language codes and that is considerably more than we need, so we'll remove 
+	 * Moment.js has been copy-pasted from the internet with *all* the possible
+	 * language codes and that is considerably more than we need, so we'll remove
 	 * the unneeded translations based on the list of supported language codes.
-	 * These translations fortunately follow a uniform pattern so that we can 
+	 * These translations fortunately follow a uniform pattern so that we can
 	 * simply include or reject them based on advanced analysis of JS comments.
 	 * Note: The language code `nb` is equivalent to our wrongly named `no` code.
 	 * @param {Set<string>} codes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "11.0.1",
+  "version": "11.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
added __mocks__ folder which is the jest's default way of mocking module. Normally we get too much noises while we're running unit tests which mostly complain about something within tradeshift-ui. So this is the way that we could get rid of those noises.

@sampi @zdlm @tynandebold

Fixes issue #
