### PR TITLE
[Footer] added a notification state to the collabbutton

### DIFF
--- a/docs/src/xhtml/components/footer/collabbutton.xhtml
+++ b/docs/src/xhtml/components/footer/collabbutton.xhtml
@@ -23,13 +23,13 @@
 						</script>
 					</figure>
 
-					<h3>Notification state</h3>
-					<p>The collaboration button can have two states: a default state and a notification state. The default state shows just the special button. The notification state shows a small notification badge over the icon. To show the button with the notification state, call the method with the onclick property and a callback, as show above, and also a notification property set to true.</p>
+					<h3>Showing a notification badge</h3>
+					<p>The collaboration button can have two states: a default state and a state showing a notification badge. The default state shows just the special button. The notification state shows the special button as well as a small notification badge over the icon. To show the button with the notification state, call the method with the onclick property and a callback, as show above, and also a badge property set to true.</p>
 
 					<figure data-ts="DoxScript">
 						<script type="runnable">
 							ts.ui.Footer.collabbutton({
-								notification: true,
+								badge: true,
 								onclick: function() {
 									ts.ui.Notification.success('Go collaborate!');
 								}
@@ -49,11 +49,27 @@
 						<script type="application/json">
 							{
 								"name": "ts.ui.Footer",
+								"methods": [
+									{
+										"name": "collabbutton",
+										"args": "(<Object|null>)",
+										"desc": "Get or set the collaboration button. Pass `null` to remove the whole button."
+									}
+								]
+							}
+						</script>
+					</div>
+					
+
+					<div data-ts="DoxApi">
+						<script type="application/json">
+							{
+								"name": "ts.ui.Footer.collabbutton",
 								"properties": [
 									{
-										"name": "notification",
+										"name": "badge",
 										"type": "boolean",
-										"desc": "Show a notification state."
+										"desc": "Show the button with a badge."
 									}
 								],
 								"methods": [
@@ -61,11 +77,6 @@
 										"name": "onclick",
 										"args": "(Function)",
 										"desc": "Get or set the collaboration button."
-									},
-									{
-										"name": "collabbutton",
-										"args": "(null)",
-										"desc": "Remove the whole button."
 									}
 								]
 							}

--- a/docs/src/xhtml/components/footer/collabbutton.xhtml
+++ b/docs/src/xhtml/components/footer/collabbutton.xhtml
@@ -9,22 +9,30 @@
 		<main data-ts="Main">
 			<article>
 				<h1>Footer collabbutton</h1>
-				<!--
-				<section class="desc">
-					<div data-ts="Note">
-						<i class="ts-icon-info"></i>
-						<p>This is an <strong>alpha</strong> preview. All features and APIs can be expected to change. The <code>collabutton</code> is particularly susceptible to changes in the near future!</p>
-					</div>
-				</section>
-				-->
 				<section>
 
-					<p>The Footer features a special button which is dedicated to launching the <em>collaboration</em> panel. To show the button, simply call the method <code>configbutton</code> with a callback.</p>
+					<p>The Footer features a special button which is dedicated to launching the <em>collaboration</em> panel. To show the button, call <code>collabbutton</code> with a onclick method and a callback.</p>
 
 					<figure data-ts="DoxScript">
 						<script type="runnable">
-							ts.ui.Footer.collabbutton(function onclick() {
-								ts.ui.Notification.success('Go collaborate!');
+							ts.ui.Footer.collabbutton({
+								onclick: function() {
+									ts.ui.Notification.success('Go collaborate!');
+								}
+							});
+						</script>
+					</figure>
+
+					<h3>Notification state</h3>
+					<p>The collaboration button can have two states: a default state and a notification state. The default state shows just the special button. The notification state shows a small notification badge over the icon. To show the button with the notification state, call the method with the onclick property and a callback, as show above, and also a notification property set to true.</p>
+
+					<figure data-ts="DoxScript">
+						<script type="runnable">
+							ts.ui.Footer.collabbutton({
+								notification: true,
+								onclick: function() {
+									ts.ui.Notification.success('Go collaborate!');
+								}
 							});
 						</script>
 					</figure>
@@ -41,11 +49,23 @@
 						<script type="application/json">
 							{
 								"name": "ts.ui.Footer",
+								"properties": [
+									{
+										"name": "notification",
+										"type": "boolean",
+										"desc": "Show a notification state."
+									}
+								],
 								"methods": [
 									{
+										"name": "onclick",
+										"args": "(Function)",
+										"desc": "Get or set the collaboration button."
+									},
+									{
 										"name": "collabbutton",
-										"args": "(<Function|null>)",
-										"desc": "Get or set the collaboration button. Pass `null` to remove the whole button."
+										"args": "(null)",
+										"desc": "Remove the whole button."
 									}
 								]
 							}

--- a/docs/src/xhtml/components/footer/gallery.xhtml
+++ b/docs/src/xhtml/components/footer/gallery.xhtml
@@ -85,8 +85,11 @@
 						<script type="runnable">
 							ts.ui.Footer.configbutton(function onclick() {
 								ts.ui.Notification.success('Go configure!');
-							}).collabbutton(function onclick() {
-								ts.ui.Notification.success('Go collaborate!');
+							}).collabbutton({
+								notification: true,
+								onclick: function() {
+									ts.ui.Notification.success('Go collaborate!');
+								}
 							});
 						</script>
 					</figure>

--- a/docs/src/xhtml/components/footer/gallery.xhtml
+++ b/docs/src/xhtml/components/footer/gallery.xhtml
@@ -86,7 +86,7 @@
 							ts.ui.Footer.configbutton(function onclick() {
 								ts.ui.Notification.success('Go configure!');
 							}).collabbutton({
-								notification: true,
+								badge: true,
 								onclick: function() {
 									ts.ui.Notification.success('Go collaborate!');
 								}

--- a/docs/src/xhtml/components/footer/index.xhtml
+++ b/docs/src/xhtml/components/footer/index.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Footer Pager</title>
+		<title>Footer</title>
 		<object data="tabs.xhtml"></object>
 	</head>
 	<body>
@@ -58,7 +58,7 @@
 									},
 									{
 										"name": "collabbutton",
-										"args": "(<Object>)",
+										"args": "(Object)",
 										"desc": "Get or set the dedicated collaboration button."
 									},
 									{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "11.0.3",
+  "version": "11.1.0",
   "description": "The Tradeshift UI Library & Framework",
   "homepage": "http://ui.tradeshift.com/",
   "bugs": {

--- a/src/runtime/edbml/scripts/ts.ui.FooterBarSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.FooterBarSpirit.edbml
@@ -22,12 +22,12 @@
 
 	function centerbar(model) {
 		<li data-ts="StatusBar" class="ts-footerbar-centerbar" id="${id}-centerbar" +
-			data-ts.model="?{model}" data-ts.visible="${footer.$showCenterBar(model)}"></li>
+			data-ts.model="?{model}" data-ts.visible="${footer.$showCenterBar(model)}" data-ts.notification="${footer.$showNotificationMarker(model)}"></li>
 	}
 
 	function backupbar(model) {
 		<li data-ts="ToolBar" class="ts-footerbar-backupbar" id="${id}-backupbar" +
-			data-ts.model="?{model}" data-ts.visible="${footer.$showBackupBar(model)}"></li>
+			data-ts.model="?{model}" data-ts.visible="${footer.$showBackupBar(model)}" data-ts.notification="${footer.$showNotificationMarker(model)}"></li>
 	}
 
 </script>

--- a/src/runtime/edbml/scripts/ts.ui.FooterBarSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.FooterBarSpirit.edbml
@@ -22,12 +22,12 @@
 
 	function centerbar(model) {
 		<li data-ts="StatusBar" class="ts-footerbar-centerbar" id="${id}-centerbar" +
-			data-ts.model="?{model}" data-ts.visible="${footer.$showCenterBar(model)}" data-ts.notification="${footer.$showNotificationMarker(model)}"></li>
+			data-ts.model="?{model}" data-ts.visible="${footer.$showCenterBar(model)}" data-ts.badge="${footer.$showBadge(model)}"></li>
 	}
 
 	function backupbar(model) {
 		<li data-ts="ToolBar" class="ts-footerbar-backupbar" id="${id}-backupbar" +
-			data-ts.model="?{model}" data-ts.visible="${footer.$showBackupBar(model)}" data-ts.notification="${footer.$showNotificationMarker(model)}"></li>
+			data-ts.model="?{model}" data-ts.visible="${footer.$showBackupBar(model)}" data-ts.badge="${footer.$showBadge(model)}"></li>
 	}
 
 </script>

--- a/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/footer/ts.ui.FooterBarModel.js
+++ b/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/footer/ts.ui.FooterBarModel.js
@@ -154,16 +154,23 @@ ts.ui.FooterBarModel = (function using(PagerModel, ActionModel, chained) {
 		 * TODO: Move this thing to the general {ts.ui.ToolBarModel}
 		 * @returns {this|ts.ui.ActionModel}
 		 */
-		collabbutton: chained(function(onclick) {
+		collabbutton: chained(function(args) {
 			var actions = this.bufferbar.actions;
 			if (arguments.length) {
 				actions.clear();
-				if (onclick !== null) {
+				if (args !== null) {
 					actions.push({
 						label: ts.ui.Footer.localize().collaboration,
 						icon: 'ts-icon-collaboration',
-						onclick: onclick
+						onclick: args.onclick
 					});
+					if (args.notification === true) {
+						this.centerbar.collabbutton = true;
+						this.backupbar.collabbutton = true;
+					} else {
+						this.centerbar.collabbutton = false;
+						this.backupbar.collabbutton = false;
+					}
 				}
 			} else {
 				return actions[0] || null;
@@ -223,6 +230,15 @@ ts.ui.FooterBarModel = (function using(PagerModel, ActionModel, chained) {
 		 */
 		$showBackupBar: function(model) {
 			return !!(model.buttons.getLength() || model.actions.getLength());
+		},
+
+		/**
+		 * Show a notification marker on collaboration icon
+		 * @param {ts.ui.ToolBarModel} model
+		 * @returns {boolean}
+		 */
+		$showNotificationMarker: function(model) {
+			return model.collabbutton;
 		}
 	});
 })(ts.ui.PagerModel, ts.ui.ActionModel, gui.Combo.chained);

--- a/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/footer/ts.ui.FooterBarModel.js
+++ b/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/footer/ts.ui.FooterBarModel.js
@@ -161,7 +161,7 @@ ts.ui.FooterBarModel = (function using(PagerModel, ActionModel, chained) {
 				if (args !== null) {
 					actions.push({
 						label: ts.ui.Footer.localize().collaboration,
-						icon: 'ts-icon-collaboration',
+						icon: 'ts-icon-comment',
 						onclick: args.onclick
 					});
 					if (args.notification === true) {

--- a/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/footer/ts.ui.FooterBarModel.js
+++ b/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/footer/ts.ui.FooterBarModel.js
@@ -164,7 +164,7 @@ ts.ui.FooterBarModel = (function using(PagerModel, ActionModel, chained) {
 						icon: 'ts-icon-comment',
 						onclick: args.onclick
 					});
-					if (args.notification === true) {
+					if (args.badge === true) {
 						this.centerbar.collabbutton = true;
 						this.backupbar.collabbutton = true;
 					} else {
@@ -233,11 +233,11 @@ ts.ui.FooterBarModel = (function using(PagerModel, ActionModel, chained) {
 		},
 
 		/**
-		 * Show a notification marker on collaboration icon
+		 * Show a badge on collaboration icon
 		 * @param {ts.ui.ToolBarModel} model
 		 * @returns {boolean}
 		 */
-		$showNotificationMarker: function(model) {
+		$showBadge: function(model) {
 			return model.collabbutton;
 		}
 	});

--- a/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/footer/ts.ui.FooterBarModel.js
+++ b/src/runtime/js/ts.ui/bars/bars-api@tradeshift.com/models/footer/ts.ui.FooterBarModel.js
@@ -165,11 +165,9 @@ ts.ui.FooterBarModel = (function using(PagerModel, ActionModel, chained) {
 						onclick: args.onclick
 					});
 					if (args.badge === true) {
-						this.centerbar.collabbutton = true;
-						this.backupbar.collabbutton = true;
+						this.centerbar.collabbutton = this.backupbar.collabbutton = true;
 					} else {
-						this.centerbar.collabbutton = false;
-						this.backupbar.collabbutton = false;
+						this.centerbar.collabbutton = this.backupbar.collabbutton = false;
 					}
 				}
 			} else {

--- a/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/api/ts.ui.Footer.js
+++ b/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/api/ts.ui.Footer.js
@@ -197,5 +197,5 @@ gui.Object.extend(ts.ui.Footer, {
 });
 
 ts.ui.Footer.localize({
-	collaboration: 'Collaborate On This'
+	collaboration: 'Open Collaboration'
 });

--- a/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/statusbar/ts.ui.StatusBarSpirit.js
+++ b/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/statusbar/ts.ui.StatusBarSpirit.js
@@ -22,10 +22,10 @@ ts.ui.StatusBarSpirit = (function using(PagerModel, Type, chained, confirmed) {
 		onlayout: null,
 
 		/**
-		 * Sets whether there needs to be a notification shown via collaboration.
+		 * Sets whether there needs to be a badge shown via collaboration.
 		 * @type {boolean}
 		 */
-		notification: false,
+		badge: false,
 
 		/**
 		 * Set the message.

--- a/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/statusbar/ts.ui.StatusBarSpirit.js
+++ b/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/statusbar/ts.ui.StatusBarSpirit.js
@@ -22,6 +22,12 @@ ts.ui.StatusBarSpirit = (function using(PagerModel, Type, chained, confirmed) {
 		onlayout: null,
 
 		/**
+		 * Sets whether there needs to be a notification shown via collaboration.
+		 * @type {boolean}
+		 */
+		notification: false,
+
+		/**
 		 * Set the message.
 		 * @alias {ts.ui.StatusBarSpirit#title}
 		 * @param @optional {string} text

--- a/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/toolbar/ts.ui.ToolBarSpirit.js
+++ b/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/toolbar/ts.ui.ToolBarSpirit.js
@@ -86,6 +86,12 @@ ts.ui.ToolBarSpirit = (function using(
 			},
 
 			/**
+			 * Sets whether there needs to be a badge shown via collaboration.
+			 * @type {boolean}
+			 */
+			badge: false,
+
+			/**
 			 * @see https://github.com/wunderbyte/spiritual-gui/issues/109
 			 */
 			onenter: function() {

--- a/src/runtime/js/ts.ui/lang/ts-lang-da.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-da.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Sø', 'Ma', 'Ti', 'On', 'To', 'Fr', 'Lø']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Samarbejde På Dette'
+	collaboration: 'Åbent Samarbejde'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-de-ch.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-de-ch.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Arbeite Daran'
+	collaboration: 'Offene Zusammenarbeit'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-de.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-de.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Arbeite Daran'
+	collaboration: 'Offene Zusammenarbeit'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-en-gb.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-en-gb.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Collaborate On This'
+	collaboration: 'Open Collaboration'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-en-us.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-en-us.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Collaborate On This'
+	collaboration: 'Open Collaboration'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-en.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-en.js
@@ -44,5 +44,5 @@ ts.ui.Autocomplete.localize({
 	}
 });
 ts.ui.Footer.localize({
-	collaboration: 'Collaborate On This'
+	collaboration: 'Open Collaboration'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-es.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-es.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Do', 'Lu', 'Ma', 'Mi', 'Ju', 'Vi', 'Sa']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Colabora En Esto'
+	collaboration: 'Colaboración Abierta'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-fi.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-fi.js
@@ -41,5 +41,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Su', 'Ma', 'Ti', 'Ke', 'To', 'Pe', 'La']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Tee Yhteistyötä Tämän Kanssa'
+	collaboration: 'Deschideți Colaborarea'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-fr.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-fr.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Di', 'Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Collaborer Sur Ce'
+	collaboration: 'Collaboration Ouverte'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-hu.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-hu.js
@@ -42,5 +42,5 @@ ts.ui.Autocomplete.localize({
 	}
 });
 ts.ui.Footer.localize({
-	collaboration: 'Együttműködjenek Erről'
+	collaboration: 'Nyissa Meg Az Együttműködést'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-id.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-id.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Mg', 'Sn', 'Sl', 'Rb', 'Km', 'jm', 'Sb']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Berkolaborasi Pada Ini'
+	collaboration: 'Kolaborasi Terbuka'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-it.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-it.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Do', 'Lu', 'Ma', 'Me', 'Gi', 'Ve', 'Sa']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Collaborare Su Questo'
+	collaboration: 'Collaborazione Aperta'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-ja.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-ja.js
@@ -8,5 +8,5 @@ ts.ui.DatePicker.localize({
 });
 
 ts.ui.Footer.localize({
-	collaboration: 'コラボレーションする'
+	collaboration: 'オープンコラボレーション'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-ms.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-ms.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Ah', 'Is', 'Se', 'Ra', 'Kh', 'Ju', 'Sa']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Bekerjasama Ini'
+	collaboration: 'Kerjasama Terbuka'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-nb-no.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-nb-no.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Sø', 'Ma', 'Ti', 'On', 'To', 'Fr', 'Lø']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Samarbeide På Dette'
+	collaboration: 'Åpen Samarbeid'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-nl.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-nl.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Zo', 'Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Werk Hier Samen Aan'
+	collaboration: 'Open Samenwerking'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-no.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-no.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Sø', 'Ma', 'Ti', 'On', 'To', 'Fr', 'Lø']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Samarbeide På Dette'
+	collaboration: 'Åpen Samarbeid'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-pl.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-pl.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Ni', 'Po', 'Wt', 'Śr', 'Cz', 'Pi', 'So']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Współpracuj W Tym'
+	collaboration: 'Otwarta Współpraca'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-pt-br.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-pt-br.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Colabore Com Isso'
+	collaboration: 'Colaboração Aberta'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-pt-pt.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-pt-pt.js
@@ -41,5 +41,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Colabore Com Isso'
+	collaboration: 'Colaboração Aberta'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-ro.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-ro.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Du', 'Lu', 'Ma', 'Mi', 'Jo', 'Vi', 'Sâ']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Colaborați Pe Acest Lucru'
+	collaboration: 'Deschideți Colaborarea'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-ru.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-ru.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Вс', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Сотрудничество в этом'
+	collaboration: 'Открытое сотрудничество'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-se.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-se.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Sö', 'Må', 'Ti', 'On', 'To', 'Fr', 'Lö']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Samarbeta På Detta'
+	collaboration: 'Öppet Samarbete'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-sv-se.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-sv-se.js
@@ -33,5 +33,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['Sö', 'Må', 'Ti', 'On', 'To', 'Fr', 'Lö']
 });
 ts.ui.Footer.localize({
-	collaboration: 'Samarbeta På Detta'
+	collaboration: 'Öppet Samarbete'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-zh-cn.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-zh-cn.js
@@ -7,5 +7,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['日', '一', '二', '三', '四', '五', '六']
 });
 ts.ui.Footer.localize({
-	collaboration: '合作就此'
+	collaboration: '开放式协作'
 });

--- a/src/runtime/js/ts.ui/lang/ts-lang-zh-tw.js
+++ b/src/runtime/js/ts.ui/lang/ts-lang-zh-tw.js
@@ -7,5 +7,5 @@ ts.ui.DatePicker.localize({
 	dayNamesMin: ['日', '一', '二', '三', '四', '五', '六']
 });
 ts.ui.Footer.localize({
-	collaboration: '合作就此'
+	collaboration: '開放式協作'
 });

--- a/src/runtime/less/ts-footers.less
+++ b/src/runtime/less/ts-footers.less
@@ -13,6 +13,14 @@
 				background-color: @ts-lite-darker;
 			}
 		}
+		&[data-ts\.notification] {
+			i.ts-icon-collaboration {
+				color: @ts-dark-liter;
+			}
+			i.ts-icon-collaboration + span {
+				color: @ts-dark-liter;
+			}
+		}
 	}
 	.ts-footerbar-bufferbar {
 		position: absolute;
@@ -21,5 +29,79 @@
 		z-index: 100;
 		visibility: hidden;
 		bottom: 0 - @ts-unit-triple;
+	}
+}
+
+.ts-toolbar.ts-spirit {
+  &[data-ts\.notification="true"] {
+		.ts-icon-collaboration::after {
+			animation-name: bounceLeft, pulseBlue;
+			animation-duration: @ts-duration-enter-mobile * 2s, @ts-duration-enter-mobile * 8s;
+			animation-timing-function: @ts-easing-enter, linear;
+			animation-delay: 0s, @ts-duration-enter-mobile * 8s;
+			animation-direction: normal, alternate;
+			animation-iteration-count: 1, infinite;
+			background: @ts-blue;
+			border-radius: 50%;
+			border: 2px solid @ts-lite-liter;
+			content: '';
+			height: 12px;
+			position: absolute;
+			right: -2px;
+			top: 0px;
+			width: 12px;
+			z-index: 20;
+		}
+		i.ts-icon-collaboration + span {
+			overflow: visible;
+			z-index: 10;
+		}
+		i.ts-icon-collaboration + span::before {
+			animation-name: bounceLeft;
+			animation-duration: @ts-duration-enter-mobile * 2s;
+			animation-timing-function: @ts-easing-enter;
+			animation-delay: 0s;
+			animation-direction: normal;
+			animation-iteration-count: 1;
+			background-color: @ts-lite-liter;
+			border-radius: 50%;
+			content: '';
+			height: 12px;
+			left: -10px;
+			position: absolute;
+			top: 10px;
+			width: 12px;
+		}
+  }
+}
+
+@keyframes bounceLeft {
+	0% {
+		transform: translateX(100%);
+	}
+	23% {
+		transform: translateX(0);
+	}
+	54% {
+		transform: translateX(7px);
+	}
+	77% {
+		transform: translateX(0);
+	}
+	92% {
+		transform: translateX(2px);
+	}
+	100% {
+		transform: translateX(0);
+	}
+}
+
+@keyframes pulseBlue {
+	0%,
+	33% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.5;
 	}
 }

--- a/src/runtime/less/ts-footers.less
+++ b/src/runtime/less/ts-footers.less
@@ -13,7 +13,7 @@
 				background-color: @ts-lite-darker;
 			}
 		}
-		&[data-ts\.notification] {
+		&[data-ts\.badge] {
 			i.ts-icon-comment {
 				color: @ts-dark-liter;
 			}
@@ -33,7 +33,7 @@
 }
 
 .ts-toolbar.ts-spirit {
-  &[data-ts\.notification="true"] {
+  &[data-ts\.badge="true"] {
 		.ts-icon-comment::after {
 			animation-name: bounceLeft, pulseBlue;
 			animation-duration: @ts-duration-enter-mobile * 2s, @ts-duration-enter-mobile * 8s;

--- a/src/runtime/less/ts-footers.less
+++ b/src/runtime/less/ts-footers.less
@@ -14,10 +14,10 @@
 			}
 		}
 		&[data-ts\.notification] {
-			i.ts-icon-collaboration {
+			i.ts-icon-comment {
 				color: @ts-dark-liter;
 			}
-			i.ts-icon-collaboration + span {
+			i.ts-icon-comment + span {
 				color: @ts-dark-liter;
 			}
 		}
@@ -34,7 +34,7 @@
 
 .ts-toolbar.ts-spirit {
   &[data-ts\.notification="true"] {
-		.ts-icon-collaboration::after {
+		.ts-icon-comment::after {
 			animation-name: bounceLeft, pulseBlue;
 			animation-duration: @ts-duration-enter-mobile * 2s, @ts-duration-enter-mobile * 8s;
 			animation-timing-function: @ts-easing-enter, linear;
@@ -52,11 +52,11 @@
 			width: 12px;
 			z-index: 20;
 		}
-		i.ts-icon-collaboration + span {
+		i.ts-icon-comment + span {
 			overflow: visible;
 			z-index: 10;
 		}
-		i.ts-icon-collaboration + span::before {
+		i.ts-icon-comment + span::before {
 			animation-name: bounceLeft;
 			animation-duration: @ts-duration-enter-mobile * 2s;
 			animation-timing-function: @ts-easing-enter;

--- a/src/runtime/less/ts-variables.less
+++ b/src/runtime/less/ts-variables.less
@@ -271,9 +271,16 @@
 
 // Animations ..................................................................
 
+@ts-debug-multiplier: 1;
+
 @ts-transition-now: 0.1s;
 @ts-transition-fast: 0.2s;
 @ts-transition-slow: 0.6s;
+
+@ts-duration-enter-mobile: 0.225s * @ts-debug-multiplier;
+@ts-duration-leave-mobile: 0.195s * @ts-debug-multiplier;
+@ts-easing-leave: cubic-bezier(0.4, 0, 1, 1);
+@ts-easing-enter: cubic-bezier(0, 0, 0.2, 1);
 
 // live examples in dropdown on http: //matthewlein.com/ceaser/
 @ts-timing-easeinquad: cubic-bezier(0.55, 0.085, 0.68, 0.53);


### PR DESCRIPTION
@sampi @zdlm @tynandebold

* New unread notification badge for the collabbutton icon, with fancy animations
  * I also updated the styles to match what was in this [Slack message](https://tradeshift.slack.com/archives/C02TX8JJ7/p1537885569000100). This was also requested by @gogozby yesterday.
![collabbutton-animation](https://user-images.githubusercontent.com/16869061/48895194-cbd94200-ee44-11e8-9e19-1074ba8e44f8.gif)
* Also note that this is a breaking change, but instead of this bumping us a major version I believe it should only bump us a minor, to `v11.1.0`.

A feature I think we could discuss adding going forward would be to allow a developer to add a url that points to an API endpoint as the `notification` parameter I've added here. The endpoint would need to return either a boolean or a number corresponding to unread messages or the like. If the endpoint returns `true` or is `> 0` we'd show the notification state. That flexibility could be a nice feature.

