### PR TITLE
Fix mailto in User Card

### DIFF
--- a/src/runtime/edbml/functions/ts.ui.usercard.edbml
+++ b/src/runtime/edbml/functions/ts.ui.usercard.edbml
@@ -84,7 +84,7 @@
 			}
 			if(email) {
 				<li class="ts-usercard-email">
-					<a href="mailto:${email}">${email}</a>
+					<a target="_top" href="mailto:${email}">${email}</a>
 				</li>
 			}
 		</ul>


### PR DESCRIPTION
@sampi @zdlm @tynandebold

There is an issue with the `mailto:email@ts.com link` action as it breaks the ui and it doesn't open the email app.

Fixes issue #706 
