### PR TITLE
Maybe the tab-indicator is showed if a second tab is introduced (Nice-to-have)

### DIFF
--- a/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/local/toolbar/ts.ui.ToolBarSpirit.js
+++ b/src/runtime/js/ts.ui/bars/bars-gui@tradeshift.com/spirits/local/toolbar/ts.ui.ToolBarSpirit.js
@@ -803,6 +803,9 @@ ts.ui.ToolBarSpirit = (function using(
 					this.dom.q('.ts-tab-indicator', ts.ui.Spirit),
 					this.dom.q('.ts-tab.ts-selected', ts.ui.Spirit)
 				);
+				if (tabs.length === 1) {
+					this.dom.q('.ts-tab-indicator', ts.ui.Spirit).dom.hide();
+				}
 			},
 
 			/**


### PR DESCRIPTION
@sampi @zdlm @tynandebold

Fixes issue #507 
