### PR TITLE
[EPD-276] Added Configuration for day selection limiter

### DIFF
--- a/docs/src/xhtml/components/datepicker/index.xhtml
+++ b/docs/src/xhtml/components/datepicker/index.xhtml
@@ -35,10 +35,12 @@
 								value: '1984-05-23',
 								min: '1984-01-01',
 								max: '1985-12-24',
-								dayLimiter: function(date){
-									// Limit selection of weekends
-									var jsDate = new Date(date.year, date.month, date.day);
-									return ![0,6].includes(jsDate.getDay());
+								onrendercell: function(cell){
+									var jsDate = new Date(cell.year, cell.month, cell.day);
+									var isWeekday = ![0,6].includes(jsDate.getDay());
+
+									cell.selectable = isWeekday;
+									cell.className = (isWeekday ? 'weekday' : 'weekend');
 								},
 								onselect: function() {
 									ts.ui.Notification.success(this.value);
@@ -83,6 +85,15 @@
 								<td><code>close</code></td>
 								<td><code>{void}</code></td>
 								<td>Close the DatePicker</td>
+							</tr>
+							<tr>
+								<td><code>onrendercell</code></td>
+								<td><code>{void}</code></td>
+								<td>
+									Called whenever the datepicker renders a cell, used to determine if a cell is selectable through
+									the <code>cell.selectable</code> property. Can also be an injection point for adding in specialized
+									classes for the current cell with <code>cell.className</code>.
+								</td>
 							</tr>
 							<tr>
 								<td><code>onselect</code></td>

--- a/docs/src/xhtml/components/datepicker/index.xhtml
+++ b/docs/src/xhtml/components/datepicker/index.xhtml
@@ -35,7 +35,13 @@
 								value: '1984-05-23',
 								min: '1984-01-01',
 								max: '1985-12-24',
+								dayLimiter: function(date){
+									// Limit selection of weekends
+									var jsDate = new Date(date.year, date.month, date.day);
+									return ![0,6].includes(jsDate.getDay());
+								},
 								onselect: function() {
+									ts.ui.Notification.success(this.value);
 									this.close();
 								},
 								onclosed: function() {
@@ -82,7 +88,7 @@
 								<td><code>onselect</code></td>
 								<td><code>{void}</code></td>
 								<td>
-									Called whenever selection changes with two 
+									Called whenever selection changes with two
 									arguments <code>newval</code> and <code>oldval<code>.
 								</td>
 							</tr>
@@ -90,7 +96,7 @@
 								<td><code>onclosed</code></td>
 								<td><code>{void}</code></td>
 								<td>
-									Event listener for close event. Called after 
+									Event listener for close event. Called after
 									aside closing animation is completed.
 								</td>
 							</tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/runtime/edbml/scripts/ts.ui.CalendarSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.CalendarSpirit.edbml
@@ -11,7 +11,7 @@
 	<?param name="nextMonth" type="string"?>
 	<?param name="minDay" type="number"?>
 	<?param name="maxDay" type="number"?>
-	<?param name="dayLimiter" type="function"?>
+	<?param name="onrendercell" type="function"?>
 
 	<table>
 		<thead>
@@ -52,11 +52,17 @@
 	}
 
 	function rendercell(cell) {
+		var cellValue = cell.stringify();
+		var cellData = Object.assign({}, cell);
+		onrendercell(cellData);
+
+		cell.cellData = cellData;
+
 		var other = cell.prev || cell.next;
 		var allow = allowcell(cell, other);
 		@name = allow ? 'accept' : 'reject';
-		@value = allow ? cell.stringify() : null;
-		@class = classname({
+		@value = allow ? cellValue : null;
+		@class = classname(cell, {
 			'ts-calendar-other' : other,
 			'ts-calendar-today' : cell.today,
 			'ts-selected' : cell.selected,
@@ -69,10 +75,25 @@
 		</td>
 	}
 
-	function classname(classes) {
-		return Object.keys(classes).filter(function(c) {
+	function classname(cell, classes) {
+		var combinedClasses;
+		var duplicateClassIndex = {};
+		var customClasses = (cell.cellData.className || '').split(' ');
+		var internalClasses = Object.keys(classes).filter(function(c) {
 			return classes[c];
-		}).join(' ') || null;
+		}) || [];
+
+		combinedClasses = internalClasses.concat(customClasses).filter(function(c){
+			if(duplicateClassIndex[c])
+			{
+				return false;
+			}
+
+			duplicateClassIndex[c] = true;
+			return true;
+		});
+
+		return combinedClasses.join(' ') || null;
 	}
 
 	function allowcell(cell, other) {
@@ -81,7 +102,7 @@
 			minDay !== all && maxDay !== (1 - all) &&
 			!lower(cell.day, minDay, !other, !prevMonth, cell.prev) &&
 			!upper(cell.day, maxDay, !other, !nextMonth, cell.next) &&
-			dayLimiter(cell)
+			cell.cellData.selectable !== false
 		);
 	}
 

--- a/src/runtime/edbml/scripts/ts.ui.CalendarSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.CalendarSpirit.edbml
@@ -11,6 +11,7 @@
 	<?param name="nextMonth" type="string"?>
 	<?param name="minDay" type="number"?>
 	<?param name="maxDay" type="number"?>
+	<?param name="dayLimiter" type="function"?>
 
 	<table>
 		<thead>
@@ -33,7 +34,7 @@
 			});
 		</tbody>
 	</table>
-	
+
 	function renderbuttons(prev, label, next) {
 		renderbutton(prev, 'ts-icon-triangleleft');
 		<th><label>${label}</label></th>
@@ -79,7 +80,8 @@
 		return (
 			minDay !== all && maxDay !== (1 - all) &&
 			!lower(cell.day, minDay, !other, !prevMonth, cell.prev) &&
-			!upper(cell.day, maxDay, !other, !nextMonth, cell.next)
+			!upper(cell.day, maxDay, !other, !nextMonth, cell.next) &&
+			dayLimiter(cell)
 		);
 	}
 

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
@@ -186,7 +186,7 @@ ts.ui.CalendarSpirit = (function() {
 			 * from the calendar/datePicker.
 			 * @type {function}
 			 */
-			dayLimiter: null,
+			onrendercell: null,
 
 			/**
 			 * Load default template and
@@ -197,7 +197,7 @@ ts.ui.CalendarSpirit = (function() {
 
 				// if supplied, import settings from the {ts.ui.DatePickerModel}
 				if (this._ismodelled()) {
-					['min', 'max', 'value', 'dayLimiter'].forEach(function(key) {
+					['min', 'max', 'value', 'onrendercell'].forEach(function(key) {
 						this[key] = this._model[key];
 					}, this);
 				}
@@ -473,11 +473,7 @@ ts.ui.CalendarSpirit = (function() {
 
 				// If no day limiter is passed, then we will create a new function for the day limiter which passes in all days
 				// as selectable dates
-				var dayLimiter =
-					this.dayLimiter ||
-					function() {
-						return true;
-					};
+				var onrendercell = this.onrendercell || function() {};
 
 				this.script.run(
 					labels,
@@ -490,7 +486,7 @@ ts.ui.CalendarSpirit = (function() {
 					nextMonth,
 					minDay,
 					maxDay,
-					dayLimiter
+					onrendercell
 				);
 			}
 		},

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
@@ -182,6 +182,13 @@ ts.ui.CalendarSpirit = (function() {
 			onselect: null,
 
 			/**
+			 * Customized function used for adding additional restrictions on what days can be selected
+			 * from the calendar/datePicker.
+			 * @type {function}
+			 */
+			dayLimiter: null,
+
+			/**
 			 * Load default template and
 			 */
 			onconfigure: function() {
@@ -190,7 +197,7 @@ ts.ui.CalendarSpirit = (function() {
 
 				// if supplied, import settings from the {ts.ui.DatePickerModel}
 				if (this._ismodelled()) {
-					['min', 'max', 'value'].forEach(function(key) {
+					['min', 'max', 'value', 'dayLimiter'].forEach(function(key) {
 						this[key] = this._model[key];
 					}, this);
 				}
@@ -464,6 +471,14 @@ ts.ui.CalendarSpirit = (function() {
 				var minDay = this._minDay(min, year, month);
 				var maxDay = this._maxDay(max, year, month);
 
+				// If no day limiter is passed, then we will create a new function for the day limiter which passes in all days
+				// as selectable dates
+				var dayLimiter =
+					this.dayLimiter ||
+					function() {
+						return true;
+					};
+
 				this.script.run(
 					labels,
 					mname,
@@ -474,7 +489,8 @@ ts.ui.CalendarSpirit = (function() {
 					prevMonth,
 					nextMonth,
 					minDay,
-					maxDay
+					maxDay,
+					dayLimiter
 				);
 			}
 		},


### PR DESCRIPTION
@sampi @zdlm @tynandebold

Adding in a configuration to the TSUI DatePicker component to allow us to add in a customizable function for further limiting the selectable days on a calendar.

Needed by EarlyPayments to allow for the following:
- Allows the EP Payments & Holiday Scheduler to restrict selectable days by days when companies are expected to be open (ie. excludes selection of holidays, weekends, etc).
