### PR TITLE
[EPD-277] Added external change event suppression

### DIFF
--- a/docs/src/xhtml/components/pager/index.xhtml
+++ b/docs/src/xhtml/components/pager/index.xhtml
@@ -13,9 +13,9 @@
 					<p>Assign <att>data-ts="Pager"</att> to a <elm>menu</elm> or <elm>nav</elm> to initialize it as a Pager. The component may be configured in HTML, complete with an inline callback, like in this example.</p>
 					<figure data-ts="DoxMarkup">
 						<script>
-							<menu data-ts="Pager" 
-								data-ts.pages="8" 
-								data-ts.page="0" 
+							<menu data-ts="Pager"
+								data-ts.pages="8"
+								data-ts.page="0"
 								data-ts.onselect="console.log(this.page)">
 							</menu>
 						</script>
@@ -24,16 +24,31 @@
 					<p>&mdash; or you can configure it via a JavaScript API, like in this example.</p>
 					<figure data-ts="DoxScript">
 						<script type="runnable">
+							let domPager = document.getElementById('mypager');
+							let domPageJump = document.getElementById('pagejumper');
+
 							ts.ui.get('#mypager', pager => {
 								pager.pages = 8;
 								pager.page = 0;
+								pager.emitExternalChanges = false;
 								pager.onselect = function(page) {
 									console.log(page);
 								};
+
+								domPageJump.onclick = function(){
+									pager.page = 0;
+								}
 							});
 						</script>
 					</figure>
+
 					<menu data-ts="Pager" id="mypager"></menu>
+					<p>
+						<button id='pagejumper' data-ts="Button" class="ts-primary">
+							<span>Jump to Page 1</span>
+						</button>
+					</p>
+
 					<p>As you can see, the Pager has no default outline and this will make it easier to embed into other components. Here's a short summary of the Pagers properties and methods.</p>
 				</section>
 				<section id="pager-api" data-important="THIS GETS INCLUDED INTO OTHER PAGES!">

--- a/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
+++ b/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
@@ -156,6 +156,8 @@ ts.ui.PagerModel = (function using(chained) {
 
 		// Private .................................................................
 
+		_internalNav: false,
+
 		/**
 		 * Increment `this.init`.
 		 */

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/pager/ts.ui.PagerSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/pager/ts.ui.PagerSpirit.js
@@ -90,6 +90,8 @@ ts.ui.PagerSpirit = (function using(Type, ButtonSpirit, CSSPlugin) {
 		 */
 		onselect: null,
 
+		emitExternalChanges: true,
+
 		/**
 		 * Handle changes. Note that the model also has an `onselect`
 		 * method, this evaluates the *spirits* `onselect` method.
@@ -100,8 +102,13 @@ ts.ui.PagerSpirit = (function using(Type, ButtonSpirit, CSSPlugin) {
 		onchange: function(changes) {
 			var model = this._model;
 			changes.forEach(function(change) {
-				if (change.object === model && change.name === 'page') {
+				if (
+					change.object === model &&
+					change.name === 'page' &&
+					(this.emitExternalChanges || model._internalNav)
+				) {
 					this._onchange(change.newValue);
+					model._internalNav = false;
 				}
 			}, this);
 		},
@@ -151,9 +158,12 @@ ts.ui.PagerSpirit = (function using(Type, ButtonSpirit, CSSPlugin) {
 		_navigate: function(button, model) {
 			var page = button.getAttribute('data-page');
 			var jump = button.getAttribute('data-jump');
+
 			if (page) {
+				model._internalNav = true;
 				model.page = Type.cast(page);
 			} else if (jump) {
+				model._internalNav = true;
 				model[jump]();
 			}
 		}


### PR DESCRIPTION
@sampi @zdlm @tynandebold

Added external change event suppression which can be toggled on or off via the component property `emitExternalChanges`.

This property is turned on by default to preserve the component's original behaviour and must be turned off explicitly to suppress the `onchange` event from emitting when something external from the pager attempts to change the selected page. 

This is vital for React.js since it sorts it's own state for the pager which can cause the 2 to get locked into a feedback loop where React state and the app's internal state keep attempting to change each other and get locked into an infinite loop, resulting the pager flickering between 2 different pages.
