### PR TITLE
[DatePicker] Add `onrendercell` callback to customize individual cells

### DIFF
--- a/docs/src/xhtml/components/datepicker/index.xhtml
+++ b/docs/src/xhtml/components/datepicker/index.xhtml
@@ -35,6 +35,26 @@
 								value: '1984-05-23',
 								min: '1984-01-01',
 								max: '1985-12-24',
+								onselect: function() {
+									this.close();
+								},
+								onclosed: function() {
+									this.dispose();
+								}
+							}).open();
+						</script>
+					</figure>
+					<p>
+						You can also use the <code>onrendercell</code> callback to manually adjust which cells are selectable, as well
+						add in additional classes per cell for styling purposes.
+					</p>
+					<figure data-ts="DoxScript">
+						<script type="runnable">
+							ts.ui.DatePicker({
+								title: "Manually Set Clickable Dates",
+								value: '1984-05-23',
+								min: '1984-01-01',
+								max: '1985-12-24',
 								onrendercell: function(cell){
 									var jsDate = new Date(cell.year, cell.month, cell.day);
 									var isWeekday = ![0,6].includes(jsDate.getDay());
@@ -53,71 +73,55 @@
 						</script>
 					</figure>
 					<p>The object argument configures a <code>ts.ui.DatePickerModel</code> as outlined below.</p>
-					<table class="api">
-						<caption>
-							<code>ts.ui.DatePickerModel</code>
-						</caption>
-						<tbody>
-							<tr>
-								<th colspan="3">Instance properties</th>
-							</tr>
-							<tr>
-								<td><code>title</code></td>
-								<td><code>{string}</code></td>
-								<td>Appears as the title of the DatePicker</td>
-							</tr>
-							<tr>
-								<td><code>value<code></td>
-								<td><code>{string}</code></td>
-								<td>
-									The selected date. Must be dash-separated, ISO 8601 formatted date string e.g. <code>2015-01-01</code>
-								</td>
-							</tr>
-							<tr>
-								<th colspan="3">Instance methods</th>
-							</tr>
-							<tr>
-								<td><code>open</code></td>
-								<td><code>{void}</code></td>
-								<td>Open the DatePicker</td>
-							</tr>
-							<tr>
-								<td><code>close</code></td>
-								<td><code>{void}</code></td>
-								<td>Close the DatePicker</td>
-							</tr>
-							<tr>
-								<td><code>onrendercell</code></td>
-								<td><code>{void}</code></td>
-								<td>
-									Called whenever the datepicker renders a cell, used to determine if a cell is selectable through
-									the <code>cell.selectable</code> property. Can also be an injection point for adding in specialized
-									classes for the current cell with <code>cell.className</code>.
-								</td>
-							</tr>
-							<tr>
-								<td><code>onselect</code></td>
-								<td><code>{void}</code></td>
-								<td>
-									Called whenever selection changes with two
-									arguments <code>newval</code> and <code>oldval<code>.
-								</td>
-							</tr>
-							<tr>
-								<td><code>onclosed</code></td>
-								<td><code>{void}</code></td>
-								<td>
-									Event listener for close event. Called after
-									aside closing animation is completed.
-								</td>
-							</tr>
-							<tr>
-								<td><code>dispose</code></td>
-								<td><code>{void}</code></td>
-								<td>Cleanup the DataPicker (recommended)</td>
-							</tr>
-						</tbody>
-					</table>
+					<div data-ts="DoxApi">
+						<script type="application.json">
+						{
+							"name": "ts.ui.DatePickerModel",
+							"properties": [
+								{
+									"name": "title",
+									"type": "string",
+									"desc": "Appears as the title of the DatePicker"
+								},
+								{
+									"name": "value",
+									"type": "string",
+									"desc": "The selected date. Must be dash-separated, ISO 8601 formatted date string e.g. 2015-01-01"
+								},
+								{
+									"name": "open",
+									"type": "void",
+									"desc": "Open the DatePicker"
+								},
+								{
+									"name": "close",
+									"type": "void",
+									"desc": "Close the DatePicker"
+								},
+								{
+									"name": "onrendercell",
+									"type": "void",
+									"desc": " Called whenever the datepicker renders a cell, used to determine if a cell is selectable through the `cell.selectable` property. Can also be an injection point for adding in specialized classes for the current cell with `cell.className`"
+								},
+								{
+									"name": "onselect",
+									"type": "void",
+									"desc": "Called whenever selection changes with two arguments `newval` and `oldval`"
+								},
+								{
+									"name": "onclosed",
+									"type": "void",
+									"desc": "Event listener for close event. Called after aside closing animation is completed."
+								},
+								{
+									"name": "dispose",
+									"type": "void",
+									"desc": "Cleanup the DataPicker (recommended)"
+								}
+							]
+						}
+						</script>
+					</div>
 				</section>
 			</article>
 	</body>

--- a/docs/src/xhtml/components/datepicker/index.xhtml
+++ b/docs/src/xhtml/components/datepicker/index.xhtml
@@ -4,113 +4,121 @@
 		<title>DatePicker</title>
 	</head>
 	<body>
-		<article>
-			<h1>DatePicker</h1>
-			<section class="desc">
-				<p>
-					Calendar widget that appears in Aside. Used in Forms for an implementation of &lt;input
-					type="date"&gt; elements.
-				</p>
-			</section>
-			<section>
-				<p>
-					The DatePicker can be launched with a JavaScript API. You should implement the
-					<code>onselect</code> method to get notified whenever the user picks a date. Note that you
-					must manually <code>open</code> and <code>close</code> the DatePicker.
-				</p>
-				<figure data-ts="DoxScript">
-					<script type="runnable">
-						var datePicker = ts.ui.DatePicker({
-							title: "Your Birthday",
-							value: '1973-03-26',
-							onselect: function(newval, oldval) {
-								ts.ui.Notification.success(this.value);
-								this.close();
-							},
-							onclosed: function() {
-								this.dispose();
-							}
-						});
-						datePicker.open();
-					</script>
-				</figure>
-				<p>You can specify a <code>min</code> and <code>max</code> value.</p>
-				<figure data-ts="DoxScript">
-					<script type="runnable">
-						ts.ui.DatePicker({
-							title: "Your Birthday",
-							value: '1984-05-23',
-							min: '1984-01-01',
-							max: '1985-12-24',
-							onselect: function() {
-								this.close();
-							},
-							onclosed: function() {
-								this.dispose();
-							}
-						}).open();
-					</script>
-				</figure>
-				<p>
-					The object argument configures a <code>ts.ui.DatePickerModel</code> as outlined below.
-				</p>
-				<table class="api">
-					<caption>
-						<code>ts.ui.DatePickerModel</code>
-					</caption>
-					<tbody>
-						<tr>
-							<th colspan="3">Instance properties</th>
-						</tr>
-						<tr>
-							<td><code>title</code></td>
-							<td><code>{string}</code></td>
-							<td>Appears as the title of the DatePicker</td>
-						</tr>
-						<tr>
-							<td><code>value</code></td>
-							<td><code>{string}</code></td>
-							<td>
-								The selected date. Must be dash-separated, ISO 8601 formatted date string e.g.
-								<code>2015-01-01</code>
-							</td>
-						</tr>
-						<tr>
-							<th colspan="3">Instance methods</th>
-						</tr>
-						<tr>
-							<td><code>open</code></td>
-							<td><code>{void}</code></td>
-							<td>Open the DatePicker</td>
-						</tr>
-						<tr>
-							<td><code>close</code></td>
-							<td><code>{void}</code></td>
-							<td>Close the DatePicker</td>
-						</tr>
-						<tr>
-							<td><code>onselect</code></td>
-							<td><code>{void}</code></td>
-							<td>
-								Called whenever selection changes with two arguments
-								<code>newval</code> and <code>oldval</code>.
-							</td>
-						</tr>
-						<tr>
-							<td><code>onclosed</code></td>
-							<td><code>{void}</code></td>
-							<td>
-								Event listener for close event. Called after aside closing animation is completed.
-							</td>
-						</tr>
-						<tr>
-							<td><code>dispose</code></td>
-							<td><code>{void}</code></td>
-							<td>Cleanup the DataPicker (recommended)</td>
-						</tr>
-					</tbody>
-				</table>
-			</section>
-		</article>
+			<article>
+				<h1>DatePicker</h1>
+				<section class="desc">
+					<p>Calendar widget that appears in Aside. Used in Forms for an implementation of &lt;input type="date"&gt; elements.</p>
+				</section>
+				<section>
+					<p>The DatePicker can be launched with a JavaScript API. You should implement the <code>onselect</code> method to get notified whenever the user picks a date. Note that you must manually <code>open</code> and <code>close</code> the DatePicker.</p>
+					<figure data-ts="DoxScript">
+						<script type="runnable">
+							var datePicker = ts.ui.DatePicker({
+								title: "Your Birthday",
+								value: '1973-03-26',
+								onselect: function(newval, oldval) {
+									ts.ui.Notification.success(this.value);
+									this.close();
+								},
+								onclosed: function() {
+									this.dispose();
+								}
+							});
+							datePicker.open();
+						</script>
+					</figure>
+					<p>You can specify a <code>min</code> and <code>max</code> value.</p>
+					<figure data-ts="DoxScript">
+						<script type="runnable">
+							ts.ui.DatePicker({
+								title: "Your Birthday",
+								value: '1984-05-23',
+								min: '1984-01-01',
+								max: '1985-12-24',
+								onrendercell: function(cell){
+									var jsDate = new Date(cell.year, cell.month, cell.day);
+									var isWeekday = ![0,6].includes(jsDate.getDay());
+
+									cell.selectable = isWeekday;
+									cell.className = (isWeekday ? 'weekday' : 'weekend');
+								},
+								onselect: function() {
+									ts.ui.Notification.success(this.value);
+									this.close();
+								},
+								onclosed: function() {
+									this.dispose();
+								}
+							}).open();
+						</script>
+					</figure>
+					<p>The object argument configures a <code>ts.ui.DatePickerModel</code> as outlined below.</p>
+					<table class="api">
+						<caption>
+							<code>ts.ui.DatePickerModel</code>
+						</caption>
+						<tbody>
+							<tr>
+								<th colspan="3">Instance properties</th>
+							</tr>
+							<tr>
+								<td><code>title</code></td>
+								<td><code>{string}</code></td>
+								<td>Appears as the title of the DatePicker</td>
+							</tr>
+							<tr>
+								<td><code>value<code></td>
+								<td><code>{string}</code></td>
+								<td>
+									The selected date. Must be dash-separated, ISO 8601 formatted date string e.g. <code>2015-01-01</code>
+								</td>
+							</tr>
+							<tr>
+								<th colspan="3">Instance methods</th>
+							</tr>
+							<tr>
+								<td><code>open</code></td>
+								<td><code>{void}</code></td>
+								<td>Open the DatePicker</td>
+							</tr>
+							<tr>
+								<td><code>close</code></td>
+								<td><code>{void}</code></td>
+								<td>Close the DatePicker</td>
+							</tr>
+							<tr>
+								<td><code>onrendercell</code></td>
+								<td><code>{void}</code></td>
+								<td>
+									Called whenever the datepicker renders a cell, used to determine if a cell is selectable through
+									the <code>cell.selectable</code> property. Can also be an injection point for adding in specialized
+									classes for the current cell with <code>cell.className</code>.
+								</td>
+							</tr>
+							<tr>
+								<td><code>onselect</code></td>
+								<td><code>{void}</code></td>
+								<td>
+									Called whenever selection changes with two
+									arguments <code>newval</code> and <code>oldval<code>.
+								</td>
+							</tr>
+							<tr>
+								<td><code>onclosed</code></td>
+								<td><code>{void}</code></td>
+								<td>
+									Event listener for close event. Called after
+									aside closing animation is completed.
+								</td>
+							</tr>
+							<tr>
+								<td><code>dispose</code></td>
+								<td><code>{void}</code></td>
+								<td>Cleanup the DataPicker (recommended)</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+			</article>
 	</body>
 </html>

--- a/src/runtime/edbml/scripts/ts.ui.CalendarSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.CalendarSpirit.edbml
@@ -11,6 +11,7 @@
 	<?param name="nextMonth" type="string"?>
 	<?param name="minDay" type="number"?>
 	<?param name="maxDay" type="number"?>
+	<?param name="onrendercell" type="function"?>
 
 	<table>
 		<thead>
@@ -33,7 +34,7 @@
 			});
 		</tbody>
 	</table>
-	
+
 	function renderbuttons(prev, label, next) {
 		renderbutton(prev, 'ts-icon-triangleleft');
 		<th><label>${label}</label></th>
@@ -51,11 +52,17 @@
 	}
 
 	function rendercell(cell) {
+		var cellValue = cell.stringify();
+		var cellData = getcelldata(cell);
+		onrendercell(cellData);
+
+		cell.cellData = cellData;
+
 		var other = cell.prev || cell.next;
 		var allow = allowcell(cell, other);
 		@name = allow ? 'accept' : 'reject';
-		@value = allow ? cell.stringify() : null;
-		@class = classname({
+		@value = allow ? cellValue : null; 
+		@class = classname(cell, {
 			'ts-calendar-other' : other,
 			'ts-calendar-today' : cell.today,
 			'ts-selected' : cell.selected,
@@ -68,10 +75,36 @@
 		</td>
 	}
 
-	function classname(classes) {
-		return Object.keys(classes).filter(function(c) {
+	function getcelldata(cell){
+		var cellData = {};
+		var prop;
+
+		for(prop in cell){
+			cellData[prop] = cell[prop];
+		}
+
+		return cellData;
+	}
+
+	function classname(cell, classes) {
+		var combinedClasses;
+		var duplicateClassIndex = {};
+		var customClasses = (cell.cellData.className || '').split(' ');
+		var internalClasses = Object.keys(classes).filter(function(c) {
 			return classes[c];
-		}).join(' ') || null;
+		}) || [];
+
+		combinedClasses = internalClasses.concat(customClasses).filter(function(c){
+			if(duplicateClassIndex[c])
+			{
+				return false;
+			}
+
+			duplicateClassIndex[c] = true;
+			return true;
+		});
+
+		return combinedClasses.join(' ') || null;
 	}
 
 	function allowcell(cell, other) {
@@ -79,7 +112,8 @@
 		return (
 			minDay !== all && maxDay !== (1 - all) &&
 			!lower(cell.day, minDay, !other, !prevMonth, cell.prev) &&
-			!upper(cell.day, maxDay, !other, !nextMonth, cell.next)
+			!upper(cell.day, maxDay, !other, !nextMonth, cell.next) &&
+			cell.cellData.selectable !== false
 		);
 	}
 

--- a/src/runtime/edbml/scripts/ts.ui.CalendarSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.CalendarSpirit.edbml
@@ -52,17 +52,13 @@
 	}
 
 	function rendercell(cell) {
-		var cellValue = cell.stringify();
-		var cellData = getcelldata(cell);
-		onrendercell(cellData);
-
-		cell.cellData = cellData;
+		onrendercell(cell);
 
 		var other = cell.prev || cell.next;
 		var allow = allowcell(cell, other);
 		@name = allow ? 'accept' : 'reject';
-		@value = allow ? cellValue : null; 
-		@class = classname(cell, {
+		@value = allow ? cell.stringify() : null;
+		@class = classname(cell.className, {
 			'ts-calendar-other' : other,
 			'ts-calendar-today' : cell.today,
 			'ts-selected' : cell.selected,
@@ -75,37 +71,19 @@
 		</td>
 	}
 
-	function getcelldata(cell){
-		var cellData = {};
-		var prop;
+	function classname(userClasses, tsClasses) {
+		var classes =
+			Object.keys(tsClasses).filter(function(c) {
+				return tsClasses[c];
+			}) || [];
 
-		for(prop in cell){
-			cellData[prop] = cell[prop];
-		}
-
-		return cellData;
+		return classes.concat(
+			(userClasses || '').split(' ').filter(function(c) {
+				return classes.indexOf(c) < 0;
+			})
+		).join(' ');
 	}
 
-	function classname(cell, classes) {
-		var combinedClasses;
-		var duplicateClassIndex = {};
-		var customClasses = (cell.cellData.className || '').split(' ');
-		var internalClasses = Object.keys(classes).filter(function(c) {
-			return classes[c];
-		}) || [];
-
-		combinedClasses = internalClasses.concat(customClasses).filter(function(c){
-			if(duplicateClassIndex[c])
-			{
-				return false;
-			}
-
-			duplicateClassIndex[c] = true;
-			return true;
-		});
-
-		return combinedClasses.join(' ') || null;
-	}
 
 	function allowcell(cell, other) {
 		var all = Number.MAX_VALUE;
@@ -113,7 +91,7 @@
 			minDay !== all && maxDay !== (1 - all) &&
 			!lower(cell.day, minDay, !other, !prevMonth, cell.prev) &&
 			!upper(cell.day, maxDay, !other, !nextMonth, cell.next) &&
-			cell.cellData.selectable !== false
+			cell.selectable !== false
 		);
 	}
 

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
@@ -182,6 +182,13 @@ ts.ui.CalendarSpirit = (function() {
 			onselect: null,
 
 			/**
+			 * Customized function used for adding additional restrictions on what days can be selected
+			 * from the calendar/datePicker.
+			 * @type {function}
+			 */
+			onrendercell: null,
+
+			/**
 			 * Load default template and
 			 */
 			onconfigure: function() {
@@ -190,7 +197,7 @@ ts.ui.CalendarSpirit = (function() {
 
 				// if supplied, import settings from the {ts.ui.DatePickerModel}
 				if (this._ismodelled()) {
-					['min', 'max', 'value'].forEach(function(key) {
+					['min', 'max', 'value', 'onrendercell'].forEach(function(key) {
 						this[key] = this._model[key];
 					}, this);
 				}
@@ -464,6 +471,10 @@ ts.ui.CalendarSpirit = (function() {
 				var minDay = this._minDay(min, year, month);
 				var maxDay = this._maxDay(max, year, month);
 
+				// If no day limiter is passed, then we will create a new function for the day limiter which passes in all days
+				// as selectable dates
+				var onrendercell = this.onrendercell || function() {};
+
 				this.script.run(
 					labels,
 					mname,
@@ -474,7 +485,8 @@ ts.ui.CalendarSpirit = (function() {
 					prevMonth,
 					nextMonth,
 					minDay,
-					maxDay
+					maxDay,
+					onrendercell
 				);
 			}
 		},


### PR DESCRIPTION
Adding in a configuration to the TSUI DatePicker component to allow us to add in a customizable function for further limiting the selectable days on a calendar.

Needed by EarlyPayments to allow for the following:

    * Allows the EP Payments & Holiday Scheduler to restrict selectable days by days when companies are expected to be open (ie. excludes selection of holidays, weekends, etc).