### PR TITLE
[FakeDateInput] Trigger `oninput` and `onchange`

### DIFF
--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.FakeDateInputSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.FakeDateInputSpirit.js
@@ -109,11 +109,8 @@ ts.ui.FakeDateInputSpirit = (function using(chained, tick, time) {
 			var realspirit = this._proxyspirit;
 			if (realspirit.value !== value) {
 				realspirit.value = value;
-				if (gui.Client.isExplorer) {
-					this._triggerchange();
-				} else {
-					this._triggerinput();
-				}
+				this._triggerinput();
+				this._triggerchange();
 			}
 		},
 


### PR DESCRIPTION
@Tradeshift/ui

React developers prefer to use `onChange` instead of `onInput`, so they see the events as not triggering.

Fixes issue #745
