### PR TITLE
[EPD-303] Adjusting behaviour of default value for datePicker

### DIFF
--- a/docs/src/xhtml/components/datepicker/index.xhtml
+++ b/docs/src/xhtml/components/datepicker/index.xhtml
@@ -66,24 +66,40 @@
 								var jsDate = new Date(cell.year, cell.month, cell.day);
 								var isWeekday = ![0,6].includes(jsDate.getDay());
 
-								cell.selectable = isWeekday;
-								cell.className = (isWeekday ? 'weekday' : 'weekend');
-							},
-							onselect: function() {
-								ts.ui.Notification.success(this.value);
-								this.close();
-							},
-							onclosed: function() {
-								this.dispose();
-							}
-						}).open();
-					</script>
-				</figure>
-				<p>
-					The object argument configures a <code>ts.ui.DatePickerModel</code> as outlined below.
-				</p>
-				<div data-ts="DoxApi">
-					<script type="application.json">
+									cell.selectable = isWeekday;
+									cell.className = (isWeekday ? 'weekday' : 'weekend');
+								},
+								onselect: function() {
+									ts.ui.Notification.success(this.value);
+									this.close();
+								},
+								onclosed: function() {
+									this.dispose();
+								}
+							}).open();
+						</script>
+					</figure>
+					<p>Here is an example DatePicker where a value is NOT set ahead of time.</p>
+					<figure data-ts="DoxScript">
+						<script type="runnable">
+							ts.ui.DatePicker({
+								title: "Date Range with no starting value",
+								value: null,
+								min: '2019-01-01',
+								max: '2019-03-31',
+								onselect: function() {
+									ts.ui.Notification.success(this.value);
+									this.close();
+								},
+								onclosed: function() {
+									this.dispose();
+								}
+							}).open();
+						</script>
+					</figure>
+					<p>The object argument configures a <code>ts.ui.DatePickerModel</code> as outlined below.</p>
+					<div data-ts="DoxApi">
+						<script type="application.json">
 						{
 							"name": "ts.ui.DatePickerModel",
 							"properties": [

--- a/spec/runtime/spirits/core-gui@tradeshift.com/ts.ui.CalendarSpirit.spec.js
+++ b/spec/runtime/spirits/core-gui@tradeshift.com/ts.ui.CalendarSpirit.spec.js
@@ -77,7 +77,7 @@ describe('ts.ui.CalendarSpirit', function() {
 
 		describe('a month containing a selected day', function() {
 			beforeEach(function() {
-				this.monthData = ts.ui.__generateDays('2014', '8', '2014', '8', '1');
+				this.monthData = ts.ui.__generateDays('2014', '8', '2014', '8', '1', true);
 			});
 
 			it('has the first day selected', function() {

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
@@ -38,7 +38,7 @@ ts.ui.CalendarSpirit = (function() {
 	/**
 	 * Exposed for easier unit testing.
 	 */
-	ts.ui.__generateDays = function(year, month, currentYear, currentMonth, currentDay, noStartingValue) {
+	ts.ui.__generateDays = function(year, month, currentYear, currentMonth, currentDay, startingValue) {
 		year = parseInt(year, 10);
 		month = parseInt(month, 10);
 		currentDay = parseInt(currentDay, 10);
@@ -56,7 +56,7 @@ ts.ui.CalendarSpirit = (function() {
 			ts.lib.Date.getDaysInMonth(year, month - 1),
 			startDay,
 			Math.ceil((numDays + startDay) / 7),
-			year === currentYear && month === currentMonth && !noStartingValue,
+			year === currentYear && month === currentMonth && startingValue,
 			year === ts.lib.Date.getCurrentFullYear() && month === ts.lib.Date.getCurrentMonth()
 		);
 	};
@@ -234,7 +234,7 @@ ts.ui.CalendarSpirit = (function() {
 				}
 				else
 				{
-					this._noStartingValue = true;
+					this._startingValue = false;
 
 					if(this.min){
 						currentDate = this.min;
@@ -300,9 +300,11 @@ ts.ui.CalendarSpirit = (function() {
 			_current: null,
 
 			/**
-			 * @type {Map}
+			 * Internal flag to determine if the datePicker component should have a starting value. Used to determine
+			 * if a date should be pre-selected and omitted from being clickable.
+			 * @type {Boolean}
 			 */
-			_noStartingValue: false,
+			_startingValue: true,
 
 			/**
 			 * @type {Map}
@@ -434,7 +436,7 @@ ts.ui.CalendarSpirit = (function() {
 					this._current.year,
 					this._current.month,
 					this._current.day,
-					this._noStartingValue
+					this._startingValue
 				);
 			},
 

--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/calendars/ts.ui.CalendarSpirit.js
@@ -38,7 +38,7 @@ ts.ui.CalendarSpirit = (function() {
 	/**
 	 * Exposed for easier unit testing.
 	 */
-	ts.ui.__generateDays = function(year, month, currentYear, currentMonth, currentDay) {
+	ts.ui.__generateDays = function(year, month, currentYear, currentMonth, currentDay, noStartingValue) {
 		year = parseInt(year, 10);
 		month = parseInt(month, 10);
 		currentDay = parseInt(currentDay, 10);
@@ -56,7 +56,7 @@ ts.ui.CalendarSpirit = (function() {
 			ts.lib.Date.getDaysInMonth(year, month - 1),
 			startDay,
 			Math.ceil((numDays + startDay) / 7),
-			year === currentYear && month === currentMonth,
+			year === currentYear && month === currentMonth && !noStartingValue,
 			year === ts.lib.Date.getCurrentFullYear() && month === ts.lib.Date.getCurrentMonth()
 		);
 	};
@@ -206,7 +206,7 @@ ts.ui.CalendarSpirit = (function() {
 				if (ts.lib.Date) {
 					this._labels = this._generateLabels();
 					this._today = ts.lib.Date.getCurrentDay();
-					this._current = ts.lib.Date.dateStringToObject(this.value || 'today');
+					this._current = this._getCurrentDate();
 					this._year = this._current.year;
 					this._month = this._current.month;
 					if (this.min) {
@@ -224,6 +224,27 @@ ts.ui.CalendarSpirit = (function() {
 					this.script.load(ts.ui.CalendarSpirit.edbml);
 					this._render();
 				}
+			},
+
+			_getCurrentDate: function(){
+				var currentDate = 'today';
+
+				if(this.value){
+					currentDate = this.value;
+				}
+				else
+				{
+					this._noStartingValue = true;
+
+					if(this.min){
+						currentDate = this.min;
+					}
+					else if(this.max){
+						currentDate = this.max;
+					}
+				}
+
+				return ts.lib.Date.dateStringToObject(currentDate);
 			},
 
 			/**
@@ -277,6 +298,11 @@ ts.ui.CalendarSpirit = (function() {
 			 * @type {Map}
 			 */
 			_current: null,
+
+			/**
+			 * @type {Map}
+			 */
+			_noStartingValue: false,
 
 			/**
 			 * @type {Map}
@@ -407,7 +433,8 @@ ts.ui.CalendarSpirit = (function() {
 					month,
 					this._current.year,
 					this._current.month,
-					this._current.day
+					this._current.day,
+					this._noStartingValue
 				);
 			},
 


### PR DESCRIPTION
@Tradeshift/ui

This Fix/Modification allows the developer to spawn a datePicker with no pre-defined value set for the component if attempting to select dates between a range.

Originally, omitting the value of the daterange would cause the calendar aside to default to today's month, which would break the component if today fell outside of the range of min/max.

This fixes 2 bugs:
- Resets the date view to either start or end of the date range, depending on whether min/max properties are set respectively (defaults to today if neither are present)
- Allows the user to select today's date if today falls within the range by removing the `ts-selected` class from that day (which blocks it's ability to be selected again). This also eliminates the visual callout which was misleading for this use-case.