### PR TITLE
[EPD-372] Fixed Native Picker UI Bug in Firefox

### DIFF
--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.DateInputSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.DateInputSpirit.js
@@ -37,6 +37,11 @@ ts.ui.DateInputSpirit = (function(tick, time) {
 		onready: function() {
 			this.super.onready();
 			this.tick.add(tick).start(tick, time);
+
+			// Change the original input into a plain text field to suppress the native datepicker cross-browser.
+			// If javascript is disabled for any reason, the browser will gracefully fallback to the native date picker
+			this.element.type = 'text';
+
 			this._createfake(ts.ui.FakeDateInputSpirit).proxy(this.element);
 		},
 


### PR DESCRIPTION
@Tradeshift/ui

Fixes a bug in the tradeshift UI forms component for date fields where clicking on the label of a date field in firefox shows the native datepicker alongside the TSUI datepicker, illustrated below:

![Screen Shot 2019-04-01 at 11 58 48 AM](https://user-images.githubusercontent.com/1810808/55352643-3a26b480-5476-11e9-9285-6d529bd7687a.png)

