### PR TITLE
Make pagers width more flexible

### DIFF
--- a/src/runtime/less/ts-pagers.less
+++ b/src/runtime/less/ts-pagers.less
@@ -17,17 +17,16 @@
 				// border: 1px solid @ts-color-gray-lighter;
 				// border-color: @ts-color-gray-light;
 				display: inline-block;
-				width: @ts-unit-double;
+				min-width: @ts-unit-double;
 				height: @ts-unit-double;
 				position: relative;
-				overflow: hidden;
+				vertical-align: middle;
+				padding: 0 @ts-unit-quarter;
 				span,
 				i {
-					.ts-mixin-maximize();
 					font-size: @ts-fontsize;
 					font-weight: @ts-fontweight-semibold;
-					line-height: 0;
-					padding-top: @ts-unit;
+					line-height: @ts-unit-double;
 				}
 				&:disabled {
 					// background-color: fade(@ts-color-gray-lighter, 25%);
@@ -54,17 +53,15 @@
 				&.ts-more span:after,
 				&.ts-less span:before {
 					content: '\2026';
-					position: absolute;
 					font-weight: @ts-fontweight;
 					font-size: @ts-fontsize-mini;
 				}
 				&.ts-less span:before {
-					margin-left: -13px;
 					//display: none;
 				}
 				svg {
 					position: relative;
-					top: (-@ts-unit-half - 1px);
+					top: @ts-unit-quarter + 2;
 					fill: @ts-color-blue;
 				}
 				&.ts-pager-first svg {

--- a/src/runtime/less/ts-pagers.less
+++ b/src/runtime/less/ts-pagers.less
@@ -61,7 +61,7 @@
 				}
 				svg {
 					position: relative;
-					top: @ts-unit-quarter + 2;
+					top: @ts-unit-quarter + 2px;
 					fill: @ts-color-blue;
 				}
 				&.ts-pager-first svg {


### PR DESCRIPTION
@Tradeshift/ui
@Chris-Xie 
Fixes issue #
The width of the pager step is fixed, when the number of pages is greater than 10000, the Numbers are connected together, when the number of pages is greater than 100000, it will not display completely. 

Let the width of the pager step be determined by the content.

Before:
![image](https://user-images.githubusercontent.com/40753347/59333564-2bd4fe80-8d2b-11e9-8a5f-fb8d595915db.png)
After:
![image](https://user-images.githubusercontent.com/40753347/59333721-85d5c400-8d2b-11e9-9500-51408b18e563.png)

