### PR TITLE
Fix the issue with web components inside ie11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.0.1",
+  "version": "12.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -359,8 +359,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "archiver": {
       "version": "1.3.0",
@@ -409,7 +408,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -2344,8 +2342,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -3693,8 +3690,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -4786,7 +4782,6 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -4852,7 +4847,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -4869,7 +4863,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4879,7 +4872,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6229,8 +6221,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -8464,7 +8455,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -11730,7 +11720,6 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/spec/spiritual/spiritual-edbml/setup/spiritual-gui.js
+++ b/spec/spiritual/spiritual-edbml/setup/spiritual-gui.js
@@ -8452,9 +8452,17 @@ switch (hack) {
 		 * @returns {number}
 		 */
 			compare: function(node1, node2) {
-				node1 = node1 instanceof gui.Spirit ? node1.element : node1;
-				node2 = node2 instanceof gui.Spirit ? node2.element : node2;
-				return node1.compareDocumentPosition(node2);
+				// When we used `ts-ui` and `elements` at the same time in ie11 it caused
+				// this error: Invalid Calling Object
+				// This will stop the web component crashing and not being able to be added
+				// after loading the `ts-ui`
+				try {
+					node1 = node1 instanceof gui.Spirit ? node1.element : node1;
+					node2 = node2 instanceof gui.Spirit ? node2.element : node2;
+					return node1.compareDocumentPosition(node2);	
+				} catch (e) {
+					return 1;
+				}
 			},
 
 		/**

--- a/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/plugins/dom/gui.DOMPlugin.js
+++ b/src/spiritual/spiritual-gui/gui-spirits@wunderbyte.com/plugins/dom/gui.DOMPlugin.js
@@ -302,9 +302,17 @@ gui.DOMPlugin = (function using(chained, guide, observer) {
 			 * @returns {number}
 			 */
 			compare: function(node1, node2) {
-				node1 = node1 instanceof gui.Spirit ? node1.element : node1;
-				node2 = node2 instanceof gui.Spirit ? node2.element : node2;
-				return node1.compareDocumentPosition(node2);
+				// When we used `ts-ui` and `elements` at the same time in ie11 it caused
+				// this error: Invalid Calling Object
+				// This will stop the web component crashing and not being able to be added
+				// after loading the `ts-ui`
+				try {
+					node1 = node1 instanceof gui.Spirit ? node1.element : node1;
+					node2 = node2 instanceof gui.Spirit ? node2.element : node2;
+					return node1.compareDocumentPosition(node2);
+				} catch (e) {
+					return 1;
+				}
 			},
 
 			/**


### PR DESCRIPTION
When we used `ts-ui` and `elements` at the same time in ie11 it caused
this error: Invalid Calling Object
This will stop the web component crashing and not being able to be added
after loading the `ts-ui`

@Tradeshift/ui

Fixes issue #
