### PR TITLE
FEAT add a pager status message

### DIFF
--- a/docs/src/xhtml/components/pager/index.xhtml
+++ b/docs/src/xhtml/components/pager/index.xhtml
@@ -62,6 +62,11 @@
 									"name": "page",
 									"type": "number",
 									"desc": "The current page index, zero based."
+								},
+								{
+									"name": "status",
+									"type": "string",
+									"desc": "Status message that is displayed on the same line as the pager."
 								}
 							],
 							"methods": [

--- a/docs/src/xhtml/components/table/paging.xhtml
+++ b/docs/src/xhtml/components/table/paging.xhtml
@@ -94,6 +94,38 @@
 						mytable.pager().page = 23;
 					</script>
 				</figure>
+				<p>
+					You can set a pager <code>status</code> message that will be shown on the Pager. Only use this for big 
+					layouts as the text can overlap with the pages if not enough room. 
+				</p>
+				<ul class="splitscreen">
+					<li>
+						<figure data-ts="DoxScript">
+							<script type="runnable">
+								$.getJSON('assets/rowdata.json', function(json) {
+									ts.ui.get('#example-pager-status', table => {
+										table
+											.cols([
+												{ label: 'ID', type: 'ts-number' },
+												{ label: 'Name', flex: 2 },
+												{ label: 'Price', type: 'ts-number'}
+											])
+											.rows(json)
+											.max(5)
+											.pager({
+												pages: 5,
+												page: 0,
+												status: '1-5 of 25'
+											})
+									});
+								});
+							</script>
+						</figure>
+					</li>
+					<li>
+						<div data-ts="Table" id="example-pager-status"></div>
+					</li>
+				</ul>
 			</section>
 		</article>
 	</body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.2.8",
+  "version": "12.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/runtime/edbml/scripts/ts.ui.ToolBarSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.ToolBarSpirit.edbml
@@ -10,7 +10,7 @@
 	var topbar =  ts.ui.TopBarModel.is(toolbar);
 	var statusbar = ts.ui.StatusBarModel.is(toolbar);
 	var hasrealtitle = !!toolbar.title;
-
+	var pagerStatus = toolbar.pager ? toolbar.pager.status : null;
 	renderleft(
 		toolbar.title || (topbar ? toolbar.defaultTitle : ''),
 		toolbar.icon,
@@ -18,23 +18,26 @@
 		toolbar.backbutton,
 		toolbar.forwardbutton,
 		toolbar.status,
+		pagerStatus,
 		toolbar.search,
 		toolbar.tabs,
 		toolbar.checkbox,
 		toolbar.$allactions()
 	);
+
 	rendercenter(id, toolbar.pager);
+
 	if(toolbar.search && toolbar.search.buttons.length) {
 		rendersearchbuttons(id, toolbar.search.buttons);
 	} else {
 		rendernormalbuttons(id, toolbar.$allbuttons());
 	}
 	
-	function renderleft(title, icon, burger, back, forward, status, search, tabs, checkbox, actions) {
+	function renderleft(title, icon, burger, back, forward, status, pagerStatus, search, tabs, checkbox, actions) {
 		var hasnavi = back || forward;
 		var hastabs = !!tabs.getLength();
 		var hasactions = !!actions.length;
-		if(mobilos || status || search || checkbox || hasactions || hastabs || hasnavi || (topbar ? hasrealtitle : title)) {
+		if(mobilos || status || pagerStatus || search || checkbox || hasactions || hastabs || hasnavi || (topbar ? hasrealtitle : title)) {
 			<menu id="${id}-items" class="ts-toolbar-menu ts-left">
 				back && renderspecialbutton(back, 'back');
 				forward && renderspecialbutton(forward, 'forward');
@@ -43,7 +46,7 @@
 				} else {
 					if(burger) {
 						renderspecialbutton(burger, 'burger');
-					} else if(icon) {
+					} else if (icon) {
 						<li id="${id}-icon" class="ts-toolbar-item ts-toolbar-icon">
 							<img src="${icon}" width="40" height="40"/>
 						</li>
@@ -57,8 +60,8 @@
 					if(checkbox && checkbox.visible) {
 						rendercheckbox(checkbox);
 					}
-					if(title || status) {
-						renderlabels(title, status, search, hasactions);
+					if(title || status || pagerStatus) {
+						renderlabels(title, status, pagerStatus, search, hasactions);
 					}
 					actions.forEach(renderbutton);
 				}
@@ -194,21 +197,28 @@
 		</li>
 	}
 
-	// title (big text) or status message (with markdown)
-	function renderlabels(title, status, search, hasactions) {
+	// title (big text) or status message (with markdown) or pager status (without markdown)
+	function renderlabels(title, status, pagerStatus, search, hasactions) {
 		if(!search || !using(search)) {
 			if(title) {
 				@class = klass('ts-toolbar-title', null, !hasactions);
 				<li id="${id}-title" @class>
 					<label>${title}</label>
 				</li>
-			} else {
+			} else if (status) {
 				@class = klass('ts-toolbar-status', null, !hasactions);
 				<li id="${id}-status" @class>
 					<label>
 						var whitelist = ['strong', 'em', 'strike', 'code'];
 						if(toolbar.linkable) whitelist.push('a');
 						out.html += ts.ui.Markdown.parse(status, whitelist);
+					</label>
+				</li>
+			} else if (pagerStatus) {
+				@class = klass('ts-toolbar-status ts-show-desktop-only');
+				<li id="${id}-status" @class>
+					<label>
+						out.html += pagerStatus;
 					</label>
 				</li>
 			}

--- a/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
+++ b/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
@@ -55,6 +55,14 @@ ts.ui.PagerModel = (function using(chained) {
 		onselect: null,
 
 		/**
+		 * Status message that is displayed on the same line as the pager.
+		 * This should be used only on a big table where the horizontal space enough to fit the text.
+		 * Does not work for smaller layouts.
+		 * @type {string}
+		 */
+		status: null,
+
+		/**
 		 * Observe myself.
 		 * Too late now, but next time: `onselect` should fire on newup (if defined)
 		 */


### PR DESCRIPTION
The pager status message is shown on the same row with the pager.
This is to save some vertical space, instead of using a separate
status toolbar when the table is big enough.

The need araise from the Document Manager layout design.

It only works for big enough horizontal space (like in Document Manager, where for 
smaller screens a different cards layout is used).

The proposed design of Document Manager:
![image](https://user-images.githubusercontent.com/1011245/62685011-8658a700-b9ca-11e9-8255-66ceb970a7a3.png)

Example from docs with this feature implemented:
![image](https://user-images.githubusercontent.com/1011245/62684971-70e37d00-b9ca-11e9-97c2-3eb6bc682199.png)

@Tradeshift/ui

See:
https://tradeshift.invisionapp.com/share/CUSV8MA9EVA#/screens/372665844
PAYDOCS-19
