### PR TITLE
Add icon colors

### DIFF
--- a/docs/src/xhtml/components/table/extras.xhtml
+++ b/docs/src/xhtml/components/table/extras.xhtml
@@ -185,7 +185,7 @@
 					The <code>type</code> configures the
 					<a data-ts="Button" href="/#components/icons/css.html">icon classname</a>
 					and the optional <code>color</code> property can be one of <code>black</code>,
-					<code>medium</code>, <code>red</code>, <code>green</code>, <code>blue</code> and
+					<code>gray-light</code>, <code>red</code>, <code>green</code>, <code>blue</code> and
 					<code>purple</code>.
 				</p>
 				<ul class="splitscreen">
@@ -196,7 +196,7 @@
 									table.rows([
 										[
 											geticon('ts-icon-sales'),
-											geticon('ts-icon-cancel', 'medium'),
+											geticon('ts-icon-cancel', 'gray-light'),
 											geticon('ts-icon-error', 'red'),
 											geticon('ts-icon-accept', 'green'),
 											geticon('ts-icon-info', 'blue'),
@@ -225,7 +225,7 @@
 								{
 									"name": "color",
 									"type": "string",
-									"desc": "The icon color."
+									"desc": "The icon color. Available colors: blue, red, orange, yellow, green, purple, pink, gray-light, slate, white, black, gray"
 								},
 								{
 									"name": "value",

--- a/src/runtime/js/ts.ui/ts.ui.js
+++ b/src/runtime/js/ts.ui/ts.ui.js
@@ -221,9 +221,6 @@ ts.ui = gui.namespace(
 
 			// amazing colors
 			CLASS_BLACK: 'ts-color-black',
-			CLASS_DARK: 'ts-color-dark',
-			CLASS_MEDIUM: 'ts-color-medium',
-			CLASS_LITE: 'ts-color-lite',
 			CLASS_WHITE: 'ts-color-white',
 			CLASS_BLUE: 'ts-color-blue',
 			CLASS_GREEN: 'ts-color-green',
@@ -231,6 +228,7 @@ ts.ui = gui.namespace(
 			CLASS_ORANGE: 'ts-color-orange',
 			CLASS_RED: 'ts-color-red',
 			CLASS_PURPLE: 'ts-color-purple',
+			CLASS_GRAY_LIGHT: 'ts-color-gray-light',
 
 			// Icons ...................................................................
 
@@ -587,16 +585,14 @@ ts.ui.BACKGROUND_COLORS = {
  */
 ts.ui.COLORS = {
 	black: ts.ui.CLASS_BLACK,
-	dark: ts.ui.CLASS_DARK,
-	medium: ts.ui.CLASS_MEDIUM,
-	lite: ts.ui.CLASS_LITE,
 	white: ts.ui.CLASS_WHITE,
 	blue: ts.ui.CLASS_BLUE,
 	green: ts.ui.CLASS_GREEN,
 	purple: ts.ui.CLASS_PURPLE,
 	yellow: ts.ui.CLASS_YELLOW,
 	orange: ts.ui.CLASS_ORANGE,
-	red: ts.ui.CLASS_RED
+	red: ts.ui.CLASS_RED,
+	'gray-light': ts.ui.CLASS_GRAY_LIGHT
 };
 
 /**

--- a/src/runtime/less/ts-icons.less
+++ b/src/runtime/less/ts-icons.less
@@ -599,3 +599,42 @@ i {
 		top: -2px;
 	}
 }
+
+[class^='ts-icon'] {
+	&.ts-color-blue {
+		color: @ts-color-blue;
+	}
+	&.ts-color-red {
+		color: @ts-color-red;
+	}
+	&.ts-color-orange {
+		color: @ts-color-orange;
+	}
+	&.ts-color-yellow {
+		color: @ts-color-yellow;
+	}
+	&.ts-color-green {
+		color: @ts-color-green;
+	}
+	&.ts-color-purple {
+		color: @ts-color-purple;
+	}
+	&.ts-color-pink {
+		color: @ts-color-pink;
+	}
+	&.ts-color-gray {
+		color: @ts-color-gray;
+	}
+	&.ts-color-slate {
+		color: @ts-color-slate;
+	}
+	&.ts-color-white {
+		color: @ts-color-white;
+	}
+	&.ts-color-black {
+		color: @ts-color-black;
+	}
+	&.ts-color-gray-light {
+		color: @ts-color-gray-light;
+	}
+}


### PR DESCRIPTION
It seems that these colors were forgotten to port from the older version
Removed `dark` `medium` and `lite` colors because it's not clear what's the color behind them
Added gray-light color for disabled state

@Tradeshift/ui

Fixes issue #854