### PR TITLE
If single page item number bigger than total, change the number to total

### DIFF
--- a/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
+++ b/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
@@ -206,7 +206,7 @@ ts.ui.PagerModel = (function using(chained) {
 			var total = this.total;
 			var number = Math.min(this.number, total);
 			var start = page * number + 1;
-			var end = (page + 1) * number < total ? (page + 1) * number : total;
+			var end = Math.min((page + 1) * number, total);
 			this.status = number > 0 && total > 0 ? start + ' - ' + end + ' (' + total + ')' : '';
 		}
 	});

--- a/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
+++ b/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
@@ -204,7 +204,7 @@ ts.ui.PagerModel = (function using(chained) {
 		_initstatus: function() {
 			var page = this.page;
 			var total = this.total;
-			var number = this.number;
+			var number = this.number > total ? total : this.number;
 			this.status =
 				number > 0 && total > 0
 					? page * number + 1 + ' - ' + (page + 1) * number + ' (' + total + ')'

--- a/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
+++ b/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
@@ -204,7 +204,7 @@ ts.ui.PagerModel = (function using(chained) {
 		_initstatus: function() {
 			var page = this.page;
 			var total = this.total;
-			var number = this.number > total ? total : this.number;
+			var number = Math.min(this.number, total);
 			this.status =
 				number > 0 && total > 0
 					? page * number + 1 + ' - ' + (page + 1) * number + ' (' + total + ')'

--- a/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
+++ b/src/runtime/js/ts.ui/core/core-api@tradeshift.com/models/pager/ts.ui.PagerModel.js
@@ -205,10 +205,9 @@ ts.ui.PagerModel = (function using(chained) {
 			var page = this.page;
 			var total = this.total;
 			var number = Math.min(this.number, total);
-			this.status =
-				number > 0 && total > 0
-					? page * number + 1 + ' - ' + (page + 1) * number + ' (' + total + ')'
-					: '';
+			var start = page * number + 1;
+			var end = (page + 1) * number < total ? (page + 1) * number : total;
+			this.status = number > 0 && total > 0 ? start + ' - ' + end + ' (' + total + ')' : '';
 		}
 	});
 })(gui.Combo.chained);


### PR DESCRIPTION
@Tradeshift/TradeshiftUI

As @aleris mentioned in  #853 

One small problem is that the number is not limited to total, for example if we have 20 per page and only 5 items in total, the pager will display 1-20 (5).

This is the fix