### PR TITLE
Changed the styling of not available dates.

### DIFF
--- a/src/runtime/less/ts-calendars.less
+++ b/src/runtime/less/ts-calendars.less
@@ -144,7 +144,7 @@
 			span {
 				cursor: default;
 			}
-			span:after {
+			span:before {
 				content: '';
 				position: absolute;
 				left: 0;


### PR DESCRIPTION
@Tradeshift/TradeshiftUI
Fixes issue #874 
Now it is not overlaps with over stylings like "today" date.
![Calendar](https://user-images.githubusercontent.com/55530374/67470424-fc75bd00-f64d-11e9-8b7c-43eac95549c2.png)

