### PR TITLE
Fix button size for micro modal

### DIFF
--- a/docs/src/xhtml/components/modals/index.xhtml
+++ b/docs/src/xhtml/components/modals/index.xhtml
@@ -121,12 +121,12 @@
 
 				<h3>Micro Size</h3>
 				<p>
-					You can add <att>ts-micro</att> class name to the modal element to have smaller modal with
+					You can add <att>ts-micro-modal</att> class name to the modal element to have smaller modal with
 					extra padding.
 				</p>
 				<figure data-ts="DoxMarkup">
 					<script type="text/html">
-						<dialog data-ts="Modal" id="exampleMicro" class="ts-micro">
+						<dialog data-ts="Modal" id="exampleMicro" class="ts-micro-modal">
 							<div data-ts="Panel">
 								<article data-ts="Box">
 									<h1>A Micro Modal Example</h1>
@@ -544,7 +544,7 @@
 			</div>
 		</dialog>
 
-		<dialog data-ts="Modal" id="exampleMicro" class="ts-micro" data-ts.title="Example Modal">
+		<dialog data-ts="Modal" id="exampleMicro" class="ts-micro-modal" data-ts.title="Example Modal">
 			<div data-ts="Panel">
 				<div data-ts="Box">
 					<h1>A Micro Modal Example</h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.2.8",
+  "version": "12.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -359,7 +359,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "archiver": {
       "version": "1.3.0",
@@ -408,6 +409,7 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -2342,7 +2344,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -3690,7 +3693,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -4782,6 +4786,7 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -4847,6 +4852,7 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
+      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -4863,6 +4869,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4872,6 +4879,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6221,7 +6229,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -8455,6 +8464,7 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -11720,6 +11730,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/src/runtime/less/ts-modals.less
+++ b/src/runtime/less/ts-modals.less
@@ -4,7 +4,8 @@
 	border-radius: 0;
 	width: 100%;
 	height: 100%;
-	&.ts-micro {
+	&.ts-micro,
+	&.ts-micro-modal {
 		max-width: 769px;
 	}
 
@@ -13,7 +14,8 @@
 			width: calc(100% - @ts-unit-double);
 			height: calc(100% - @ts-unit-double);
 			margin: @ts-unit;
-			&.ts-micro {
+			&.ts-micro,
+			&.ts-micro-modal {
 				height: calc(100% - (@ts-unit * 5 * 2));
 				margin: (@ts-unit * 5) auto;
 			}


### PR DESCRIPTION
With ts-micro class name the buttons in the modal also got micro sized.
To fix this changed the class name for making a modal micro.
To not making it a breaking change kept the `ts-micro` class name, but removed it from documentation.

@Tradeshift/TradeshiftUI

Fixes issue https://tradeshift.slack.com/archives/C02TX8JJ7/p1572865758063200
#885 