### PR TITLE
IE11 bug fix

### DIFF
--- a/src/spiritual/spiritual-gui/gui@wunderbyte.com/concepts/gui.Action.js
+++ b/src/spiritual/spiritual-gui/gui@wunderbyte.com/concepts/gui.Action.js
@@ -388,8 +388,9 @@ gui.Action = (function using(confirmed, chained) {
 					 * @param {Window} win Remote window
 					 * @param {String} uri target origin
 					 * @param {String} key Spiritkey of xdomain IframeSpirit (who will relay the action)
-					 * SetTimeout because the bug in IE11. It will show null exception when you remove
-					 * an iframe.
+					 * SetTimeout because the bug in IE11. It will show null exception when you ues ts.io
+					 * tradeshift-ui and ts-elements polyfill and remove an iframe. Here will send message
+					 * to the deleted iframe. The webcomponents polyfill will show the error in IE11.
 					 */
 					transcend: function(win, uri, key) {
 						var msg = gui.Action.stringify(action, key);

--- a/src/spiritual/spiritual-gui/gui@wunderbyte.com/concepts/gui.Action.js
+++ b/src/spiritual/spiritual-gui/gui@wunderbyte.com/concepts/gui.Action.js
@@ -388,10 +388,14 @@ gui.Action = (function using(confirmed, chained) {
 					 * @param {Window} win Remote window
 					 * @param {String} uri target origin
 					 * @param {String} key Spiritkey of xdomain IframeSpirit (who will relay the action)
+					 * SetTimeout because the bug in IE11. It will show null exception when you remove
+					 * an iframe.
 					 */
 					transcend: function(win, uri, key) {
 						var msg = gui.Action.stringify(action, key);
-						win.postMessage(msg, '*'); // uri
+						setTimeout(function() {
+							win.postMessage(msg, '*'); // uri
+						}, 10);
 					}
 				});
 				return action;


### PR DESCRIPTION
When we use ts.io, tradeshift-ui and ts-element polyfill together, will show a null exception in IE11. This is the fix for that

`Unable to get property 'getPrototypeOf' of undefined or null reference`

@Tradeshift/TradeshiftUI

Fixes issue #
