### PR TITLE
NAV-416. Added a column property to disable markdown.

### DIFF
--- a/docs/src/xhtml/components/table/formatting.xhtml
+++ b/docs/src/xhtml/components/table/formatting.xhtml
@@ -106,6 +106,57 @@
 						<div data-ts="Table" id="table4"></div>
 					</li>
 				</ul>
+				<p>
+					You can disable the Markdown in the table by call the <code>disableMarkdown</code> method.
+					To enable it again you can call the <code>enableMarkdown</code> method.
+				</p>
+				<ul class="splitscreen">
+					<li>
+						<figure data-ts="DoxScript">
+							<script type="runnable">
+								ts.ui.get('#table5', function(table) {
+									table.disableMarkdown();
+									table.rows([
+										['*Italic text*'],
+										['**Strong text**'],
+										['~~Strike text~~'],
+										['`monotype text`']
+									]);
+								});
+							</script>
+						</figure>
+					</li>
+					<li>
+						<div data-ts="Table" id="table5"></div>
+					</li>
+				</ul>
+				<p>
+					You can disable the Markdown in specific column by column's property
+					<code>markdownFormatting</code>:
+				</p>
+				<ul class="splitscreen">
+					<li>
+						<figure data-ts="DoxScript">
+							<script type="runnable">
+								ts.ui.get('#table6', function(table) {
+									table.cols([
+										{label: 'Disabled markdown column', markdownFormatting: false},
+										{label: 'Not disabled markdown column'}
+									]);
+									table.rows([
+										['*Italic text*', '*Italic text*'],
+										['**Strong text**', '**Strong text**'],
+										['~~Strike text~~', '~~Strike text~~'],
+										['`monotype text`', '`monotype text`']
+									]);
+								});
+							</script>
+						</figure>
+					</li>
+					<li>
+						<div data-ts="Table" id="table6"></div>
+					</li>
+				</ul>
 			</section>
 		</article>
 	</body>

--- a/spec/runtime/spirits/table-gui@tradeshift.com/ts.ui.TableSpirit.spec.js
+++ b/spec/runtime/spirits/table-gui@tradeshift.com/ts.ui.TableSpirit.spec.js
@@ -290,6 +290,44 @@ describe('ts.ui.TableSpirit', function likethis() {
 			});
 		});
 
+		it('should support disabling of markdown via disableMarkdown table method', function(done) {
+			setup(function(spirit, dom) {
+				spirit.disableMarkdown();
+				spirit.rows([
+					['*Italic text*'],
+					['**Strong text**'],
+					['~~Strike text~~'],
+					['`monotype text`']
+				]);
+				sometime(function later() {
+					expect(spirit.element.innerHTML).not.toContain('</em>');
+					expect(spirit.element.innerHTML).not.toContain('</strong>');
+					expect(spirit.element.innerHTML).not.toContain('</del>');
+					expect(spirit.element.innerHTML).not.toContain('</code>');
+					done();
+				});
+			});
+		});
+
+		it('should support disabling of markdown via col property', function(done) {
+			setup(function(spirit, dom) {
+				spirit.cols([{ markdownFormatting: false }]);
+				spirit.rows([
+					['*Italic text*'],
+					['**Strong text**'],
+					['~~Strike text~~'],
+					['`monotype text`']
+				]);
+				sometime(function later() {
+					expect(spirit.element.innerHTML).not.toContain('</em>');
+					expect(spirit.element.innerHTML).not.toContain('</strong>');
+					expect(spirit.element.innerHTML).not.toContain('</del>');
+					expect(spirit.element.innerHTML).not.toContain('</code>');
+					done();
+				});
+			});
+		});
+
 		it('should support link', function(done) {
 			setup(function(spirit, dom) {
 				spirit.linkable();
@@ -338,6 +376,18 @@ describe('ts.ui.TableSpirit', function likethis() {
 				spirit.rows([['Please (visit)[Trade(s)hift](http://www.tradeshift.com)']]);
 				sometime(function later() {
 					expect(spirit.element.innerHTML).toContain('(visit)<a');
+					done();
+				});
+			});
+		});
+
+		it('should not render link with disabled markdown', function(done) {
+			setup(function(spirit, dom) {
+				spirit.linkable();
+				spirit.disableMarkdown();
+				spirit.rows([['Please visit [Tradeshift](http://www.tradeshift.com)']]);
+				sometime(function later() {
+					expect(spirit.element.innerHTML).not.toContain('Tradeshift</a>');
 					done();
 				});
 			});

--- a/src/runtime/edbml/functions/ts.ui.tablerows.edbml
+++ b/src/runtime/edbml/functions/ts.ui.tablerows.edbml
@@ -69,6 +69,10 @@
 				}
 				if(ts.ui.Model.is(cell)) {
 					out.html += cell.render();
+				} else if(col && !col.markdownFormatting || !table.markdownFormatting) {
+					<p>
+						out.html += edbml.safetext(cell.text);
+					</p>
 				} else {
 					out.html += Markdown.parse(cell.text, whitelist);
 				}

--- a/src/runtime/js/ts.ui/tables/tables-api@tradeshift.com/models/cols/ts.ui.TableColModel.js
+++ b/src/runtime/js/ts.ui/tables/tables-api@tradeshift.com/models/cols/ts.ui.TableColModel.js
@@ -172,6 +172,12 @@ ts.ui.TableColModel = (function using(chained) {
 		sort: null,
 
 		/**
+		 * Applies a markdown formatting to the cells in this column or not.
+		 * @type {boolean}
+		 */
+		markdownFormatting: true,
+
+		/**
 		 * Is (cell content) of type number?
 		 * @returns {boolean}
 		 */

--- a/src/runtime/js/ts.ui/tables/tables-api@tradeshift.com/models/ts.ui.TableModel.js
+++ b/src/runtime/js/ts.ui/tables/tables-api@tradeshift.com/models/ts.ui.TableModel.js
@@ -221,6 +221,12 @@ ts.ui.TableModel = (function using(RowCollection, Type, Model) {
 		linkable: false,
 
 		/**
+		 * The Table should render cell's content via Markdown?
+		 * @type {boolean}
+		 */
+		markdownFormatting: true,
+
+		/**
 		 * @type {boolean}
 		 */
 		editable: false,

--- a/src/runtime/js/ts.ui/tables/tables-gui@tradeshift.com/spirits/ts.ui.TableSpirit.js
+++ b/src/runtime/js/ts.ui/tables/tables-gui@tradeshift.com/spirits/ts.ui.TableSpirit.js
@@ -1115,6 +1115,25 @@ ts.ui.TableSpirit = (function using(
 			this._model.linkable = false;
 		}),
 
+		// Markdown ................................................................
+
+		/**
+		 * The table supports markdown out of the box, but you can enable/disable it.
+		 * @param @optional {function} onlink
+		 * @returns {ts.ui.TableSpirit}
+		 */
+		enableMarkdown: chained(function() {
+			this._model.markdownFormatting = true;
+		}),
+
+		/**
+		 * Disables Markdown render in table.
+		 * @returns {ts.ui.TableSpirit}
+		 */
+		disableMarkdown: chained(function() {
+			this._model.markdownFormatting = false;
+		}),
+
 		// Collaboration ...........................................................
 
 		/**


### PR DESCRIPTION
@Tradeshift/TradeshiftUI

Fixes issue #964

- Added two methods to the table component, `disableMarkdown`/`enableMarkdown` so developer can completely disable and enable again the markdown formatting in table cells.
- Added a new boolean property `markdownFormatting` to a column config so developer can completely disable Markdown processing of the cell's content in this column by setting it to `false`. By default it is set to `true`.

![Screenshot 2020-10-22 at 17 21 09](https://user-images.githubusercontent.com/55530374/96903020-8d67ba00-1495-11eb-849a-0b96f58567a6.png)

