### PR TITLE
feat(DateInput): add support for DatePickerModel.deselectable

### DIFF
--- a/docs/src/xhtml/components/forms/index.xhtml
+++ b/docs/src/xhtml/components/forms/index.xhtml
@@ -163,6 +163,7 @@
 								<label>
 									<span>Date</span>
 									<input type="date"
+										data-ts.deselectable="true"
 										value="2015-01-01"
 										min="2014-01-01"
 										max="2016-01-01"/>

--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.DateInputSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.DateInputSpirit.js
@@ -11,6 +11,14 @@ ts.ui.DateInputSpirit = (function(tick, time) {
 
 	return ts.ui.InputSpirit.extend({
 		/**
+		 * Deselectable. This may be set in the markup:
+		 * <input data-ts.deselectable="true" />
+		 * If not set, we fallback to default action.
+		 * @type {boolean}
+		 */
+		deselectable: false,
+
+		/**
 		 * Min date.
 		 * @type {string}
 		 */

--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.FakeDateInputSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.FakeDateInputSpirit.js
@@ -88,6 +88,7 @@ ts.ui.FakeDateInputSpirit = (function using(chained, tick, time) {
 					value: real.value,
 					min: real.min,
 					max: real.max,
+					deselectable: real.deselectable,
 					onselect: function(value) {
 						spirit._syncreal(value);
 						spirit._syncfake();


### PR DESCRIPTION
Sometimes we need to be able to deselect the selected date. This PR aims to add support for DatePickerModel.deselectable to DateInputSpirit.
