### PR TITLE
fix(FakeDateInputSpirit): _syncfake should also sync the disabled state

### DIFF
--- a/spec/runtime/spirits/core-gui@tradeshift.com/ts.ui.TimeSpirit.spec.js
+++ b/spec/runtime/spirits/core-gui@tradeshift.com/ts.ui.TimeSpirit.spec.js
@@ -60,7 +60,7 @@ describe('ts.ui.TimeSpirit', function likethis() {
 				code +
 				'" datetime="' +
 				(currentYear - 2) +
-				'-11-04 03:59:33"></time>');
+				'-01-01 00:00:00"></time>');
 		});
 	});
 });

--- a/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.FakeDateInputSpirit.js
+++ b/src/runtime/js/ts.ui/forms/forms-gui@tradeshift.com/spirits/ts.ui.FakeDateInputSpirit.js
@@ -128,6 +128,9 @@ ts.ui.FakeDateInputSpirit = (function using(chained, tick, time) {
 			if (realspirit.element.placeholder !== this.element.placeholder) {
 				this.element.placeholder = realspirit.element.placeholder;
 			}
+			if (realspirit.element.disabled !== this.element.disabled) {
+				this.element.disabled = realspirit.element.disabled;
+			}
 		}
 	});
 })(gui.Combo.chained, ts.ui.FieldSpirit.TICK_SYNC, ts.ui.FieldSpirit.TICK_TIME);


### PR DESCRIPTION
@Tradeshift/TradeshiftUI

Fixes issue APA-1437: if you have a date picker disabled by default and then you decide later on to enable it the UI will still show it as disabled, altho you you will be able to click on it and select a date