### PR TITLE
Fix the wrong text color for warning lite tags

### DIFF
--- a/src/runtime/less/ts-tags.less
+++ b/src/runtime/less/ts-tags.less
@@ -284,7 +284,7 @@
 		figcaption,
 		dd,
 		dt {
-			color: @ts-color-black;
+			color: @ts-color-orange-darker;
 		}
 	}
 


### PR DESCRIPTION
@Tradeshift/TradeshiftUI

Fixes issue #986 

https://www.figma.com/file/GIQREuPZ2iGA1kRpjlpehT/UI-Components?node-id=0%3A1081

![Screenshot 2021-03-04 at 09 46 04](https://user-images.githubusercontent.com/22932169/109937203-f5919c80-7cce-11eb-8735-16556b83f78f.png)
