### PR TITLE
build: use new setup-node instead of npm-install action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,14 +16,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: 'npm'
 
       - name: 📥 Download deps
-        uses: tradeshift/npm-install@v1
-        with:
-          useLockFile: true
+        run: npm ci
 
       - name: ▶️ Run tests
         run: npm test


### PR DESCRIPTION
setup-node has dependency caching now, so lets use that instead of npm-install.
