### PR TITLE
build: Updated docs generator code to use changed API of cheerio library

### DIFF
--- a/docs/tasks/processor.js
+++ b/docs/tasks/processor.js
@@ -166,7 +166,7 @@ function highlite($) {
 				type = script.attr('type') || 'text/plain';
 				lang = klass.split('-')[1];
 				gram = prism.languages[lang];
-				code = unindent(script.text()).replace(/scrxpt/g, 'script');
+				code = unindent(script.html()).replace(/scrxpt/g, 'script');
 				setup($, figure, script, klass, type, lang, gram, code);
 				code = klass === 'language-javascript' ? compile(code).code : code;
 				figure.attr('data-ts.code', encodeURIComponent(code));
@@ -176,7 +176,7 @@ function highlite($) {
 	$('[data-ts=DoxApi]').each(function(i, table) {
 		script = $(table).find('script');
 		if (script) {
-			code = unindent(script.text());
+			code = unindent(script.html());
 			$(table).attr('data-ts.code', encodeURIComponent(code));
 			script.remove();
 		}
@@ -341,6 +341,11 @@ function includetags($, source) {
 				var pre = preparsers(include, $);
 				var post = postparsers(include, $);
 				html = fetchinclude(file, hash, pre, post);
+				if (href === 'tabs.xhtml') {
+					// if it is a "tabs.xhtml" we need to append it to <head>
+					// because it contains a list of "<link prefetch>"
+					include.appendTo('head');
+				}
 			} else {
 				console.log('Human error: "' + file + '" not found!!!');
 				console.log(badinclude(file));


### PR DESCRIPTION
After upgrade of Cheerio library from `0.22.0` to `1.0.0-rc.10` in the PR https://github.com/Tradeshift/tradeshift-ui/pull/1001 our docs generator stop working, at least in local dev mode.
- One of the issues was empty script blocks, which actually was a  breaking change in cheerio: https://github.com/cheeriojs/cheerio/issues/1050
- Another one I did not find the root cause, but after upgrade our placeholder for navigation tabs start added to the html `<body>` instead of `<head>`. To fix this I added a manual `appendTo("head")` for these blocks which is solved the issue.