### PR TITLE
build: replace 'string' package dependency with custom function to check is a file ends with '.html' or not

### DIFF
--- a/docs/Gruntfile.js
+++ b/docs/Gruntfile.js
@@ -5,7 +5,6 @@ const bsshooter = require('./tasks/shooter.js');
 const cheerio = require('cheerio');
 const path = require('path');
 const fs = require('fs');
-const S = require('string');
 
 var stackconf = {
 	username: process.env.BROWSERSTACK_USERNAME,
@@ -468,10 +467,13 @@ module.exports = function(grunt) {
 			});
 			return pagesIndex;
 		}
+		function isHTMLFile(filename) {
+			return filename.substring(filename.length - 5, filename.length) === '.html';
+		}
 		function processFile(abspath, filename) {
 			var pageIndex;
 
-			if (S(filename).endsWith('.html')) {
+			if (isHTMLFile(filename)) {
 				pageIndex = processHTMLFile(abspath, filename);
 			}
 			return pageIndex;
@@ -488,7 +490,6 @@ module.exports = function(grunt) {
 			if (!(raw.includes('robots') && raw.includes('noindex'))) {
 				var content = ignoreHTML(raw);
 
-				// var title = require('string')(raw).between('<title>', '</title>').s;
 				var title;
 				var left = '<title>';
 				var right = '</title>';
@@ -502,13 +503,11 @@ module.exports = function(grunt) {
 					title = raw.slice(startPos + left.length, endPos);
 				}
 
-				// var href = require('string')(abspath).chompLeft(prefix).s;
 				var href = abspath;
 				if (abspath.indexOf(prefix) === 0) {
 					href = abspath.slice(prefix.length);
 				}
 
-				// content = require('string')(content).trim().stripTags().stripPunctuation().s;
 				content = content
 					.trim()
 					.replace(RegExp('</?[^<>]*>', 'gi'), '')

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3435,12 +3435,20 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "morgan": {
@@ -4664,12 +4672,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string": {
-      "version": "3.3.3",
-      "resolved": "https://npm.tradeshift.net/repository/npm-all/string/-/string-3.3.3.tgz",
-      "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=",
-      "dev": true
-    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -5093,10 +5095,9 @@
       "dev": true
     },
     "urijs": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
-      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==",
-      "dev": true
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
     },
     "urix": {
       "version": "0.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,6 @@
     "less": "^3.9.0",
     "load-grunt-tasks": "^3.5.0",
     "selenium-webdriver": "^3.3.0",
-    "serve-static": "^1.12.4",
-    "string": "^3.3.3"
+    "serve-static": "^1.12.4"
   }
 }


### PR DESCRIPTION
Because the package `grunt-spiritual-edbml-tmpfix` hijacking `String.prototype` with non-standard polyfills it is impossible to use a standard `String.prototype.endsWith()` function, so I had to implement the custom one-line function to check is the filename ends with `.html` or not.

---
What's wrong with the custom implementation in `grunt-spiritual-edbml-tmpfix`? It looks like this:
```js
String.prototype.endsWith = function (string) {
  return this.indexOf(string) === this.length - 1;
};
```
The problems are:
- Anything longer than 1 character will fail the check.
- If we have two occurrences of the search term in the string it will also fail.

You can see the implementation of `String.prototype.endsWith` in `grunt-spiritual-edbml-tmpfix` here: https://unpkg.com/grunt-spiritual-edbml-tmpfix@0.3.1/tasks/things/compiler.js