### PR TITLE
fix(UserImage): crashes for numeric user(team)name

### DIFF
--- a/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/images/ts.ui.ImageSpirit.js
+++ b/src/runtime/js/ts.ui/core/core-gui@tradeshift.com/spirits/images/ts.ui.ImageSpirit.js
@@ -78,7 +78,7 @@ ts.ui.ImageSpirit = (function using(fontcss, UNIT_DOUBLE) {
 		if (regExp.test(name)) {
 			return regExp.exec(name)[1].toUpperCase();
 		}
-		var names = name.split(/\s+/);
+		var names = name.toString().split(/\s+/);
 		var first = names.shift();
 		var last = names.pop() || '';
 		return (first[0] + (last[0] || '')).toUpperCase();


### PR DESCRIPTION
Since it's being used for some other cases that are not actual person name, which they can be numbers, so converting it to string to have the split method.

@Tradeshift/TradeshiftUI

Fixes issue #
