### PR TITLE
Release 12.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.7.1",
+  "version": "12.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.7.1",
+  "version": "12.8.0",
   "description": "The Tradeshift UI Library & Framework",
   "homepage": "https://ui.tradeshift.com/",
   "bugs": {


### PR DESCRIPTION
* Merge pull request #1017 from Tradeshift/paya-1423 (a9512d4a)
* feat(tags): Add properties to tags so it can render in tables (2669d795)
* Merge pull request #1015 from Tradeshift/tooltip-on-aside (36be8dd2)
* feat(aside): add optional tooltip on header (f7a30e06)
* Merge pull request #1013 from Tradeshift/kian/fix-user-image-error-with-numbers (4ef1656d)
* fix(UserImage): crashes for numeric user(team)name (24061e91)
* Merge pull request #1012 from Tradeshift/kian/peaa-639 (6fe7d13f)
* [PEAA-639] Bump grunt-contrib-compress version (4c79054b)
* Merge pull request #1011 from Tradeshift/dependabot/npm_and_yarn/docs/jszip-3.7.1 (794a903b)
* build(deps): bump jszip from 3.1.5 to 3.7.1 in /docs (e4ebb14e)
* Merge pull request #1010 from Tradeshift/dependabot/npm_and_yarn/docs/path-parse-1.0.7 (f6367c6f)
* build(deps): bump path-parse from 1.0.6 to 1.0.7 in /docs (401204c1)
* Merge pull request #1009 from Tradeshift/dependabot/npm_and_yarn/path-parse-1.0.7 (30cb9b1b)
* build(deps): bump path-parse from 1.0.6 to 1.0.7 (7b16c73d)
* Merge pull request #1008 from Tradeshift/elkin/remove-string-dep (86fba3fe)
* build: replace 'string' package dependency with custom function to check is a file ends with '.html' or not (0309e94c)
* Merge pull request #1007 from Tradeshift/elkin/fix-docs-processor (306d5345)
* build: Updated docs generator code to use changed API of cheerio library (574a1a7b)
* Merge pull request #1005 from Tradeshift/gha (f57d0ff6)
* build: use new setup-node instead of npm-install action (c29d55be)
* Merge pull request #1004 from Tradeshift/gha (20e9997e)
* build: github actions fix for main workflow (d5040bc6)
* Merge pull request #1003 from Tradeshift/gha (75bc1d47)
* build: set up build on github actions (f558265a)
* Merge pull request #1001 from Tradeshift/ZTN-6546 (d0b41686)
* chore(docs/package.json): bump up grunt-link-checker (bb090e84)
* chore(package.json): bump up grunt-concurrent in order to get trim-newlines upgraded (d8f7f0b9)
* chore(docs/package.json): bump up grunt-concurrent in order to get trim-newlines upgraded (8daf4ba9)
* chore(docs/package.json): bump up cheerio in order to get css-what upgraded (27efecdb)
* Merge pull request #1000 from Tradeshift/dependabot/npm_and_yarn/lodash-4.17.21 (c6420ddf)
* Bump lodash from 4.17.20 to 4.17.21 (bd4fc03d)
* Merge pull request #999 from Tradeshift/peaa-475 (c27e05b1)
* chore(nvm/travis): bump up node version; 8 -> 14 (d76d0f58)
* chore(deps-dev): update ali-oss in order to get netmask updated (d4ec1cd7)
* chore(deps-dev): bump release-it 7.6.1 -> 14.7.0 (1aa03cb7)
* chore(deps-dev): remove unused node-static (87e27b95)
* chore(deps-dev): update grunt-postcss to 0.9.0 (c10626ec)
* chore(deps-dev): update lint-staged and pkg-lock (9866ed7c)
* Merge pull request #998 from Tradeshift/dependabot/npm_and_yarn/hosted-git-info-2.8.9 (741a1b24)
* Bump hosted-git-info from 2.7.1 to 2.8.9 (38681595)
* Merge pull request #995 from Tradeshift/dependabot/npm_and_yarn/docs/grunt-1.3.0 (3523aa65)
* Bump grunt from 1.0.3 to 1.3.0 in /docs (1a9de478)
* Merge pull request #996 from Tradeshift/dependabot/npm_and_yarn/docs/lodash-4.17.21 (89d7d098)
* Bump lodash from 4.17.19 to 4.17.21 in /docs (c56f70a3)
* Merge pull request #997 from Tradeshift/dependabot/npm_and_yarn/docs/hosted-git-info-2.8.9 (44a8aee7)
* Bump hosted-git-info from 2.7.1 to 2.8.9 in /docs (74e9315b)
* Merge pull request #993 from Tradeshift/dependabot/npm_and_yarn/y18n-4.0.1 (2a437732)
* Bump y18n from 4.0.0 to 4.0.1 (3d2de1d2)
* Merge pull request #992 from Tradeshift/kian/update-team-in-catalog (6e65965e)
* Change the team in backstage catalog (9148e3ca)
* Merge pull request #990 from Tradeshift/kian/release-12.7.1 (b331309b)

[PEAA-639]: https://tradeshift.atlassian.net/browse/PEAA-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ