### PR TITLE
PEAA-919: sanitize values before put them inside html markup to eliminate the XSS vulnerability.

### DIFF
--- a/src/runtime/edbml/scripts/ts.ui.AutocompleteDropdownSpirit.edbml
+++ b/src/runtime/edbml/scripts/ts.ui.AutocompleteDropdownSpirit.edbml
@@ -18,7 +18,7 @@
 			(autocomplete.filteredAutocompleteList || []).forEach(function(item) {
 				var json = JSON.stringify(item);
 				<li onclick="#{spirit._onselect(item)}" data-item="${json}">
-					out.html += printLabel(item, filter); 
+					out.html += edbml.safetext(printLabel(item, filter));
 				</li>
 			});
 		</menu>


### PR DESCRIPTION
Added a call of sanitize function that we use in several components, e.g. in `table` and `markdown` before put values inside the html markup. It should not affect actual values, so filtering and data in js model and in events will not change.
