### PR TITLE
Release 12.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.8.1",
+  "version": "12.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.8.1",
+  "version": "12.8.2",
   "description": "The Tradeshift UI Library & Framework",
   "homepage": "https://ui.tradeshift.com/",
   "bugs": {


### PR DESCRIPTION
Release a patch version with correct package.json.
In previous version (12.8.1) there was a mistake that leads to an error on an install phase so the package basically cannot be installed.
Now I published a new version 12.8.2 where this problem solved.