### PR TITLE
chore: adds GHA workflows for ts-ui v11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - v11
 
 jobs:
   validate:
@@ -18,7 +19,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: ${{ github.ref == 'refs/heads/v11' && 8 || 14 }}
           cache: 'npm'
 
       - name: 📥 Download deps

--- a/.github/workflows/v11-deploy-to-s3.yml
+++ b/.github/workflows/v11-deploy-to-s3.yml
@@ -1,0 +1,35 @@
+name: Deploy v11 to S3
+
+on: workflow_dispatch
+
+jobs:
+  deploy:
+    name: Build and deploy v11 to s3
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: v11
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 8
+          cache: 'npm'
+
+      - name: 🐗  Install grunt-cli
+        run: npm install -g grunt-cli
+
+      - name: 📥  Download deps
+        run: npm ci
+
+      - name: ▶️ Build
+        run: npm run build
+
+      - name: ▶️ Deploy to s3
+        run: npm run deploy-s3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_CHROME_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_CHROME_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
@Tradeshift/TradeshiftUI

Adds a specific workflow for deploying tradeshift-ui v11
Adds `v11` to watched branches in the main GHA workflow (tests), makes node version depend on branch name (being "v11" or not).