### PR TITLE
fix(less): wrap width division in parens so Less computes it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.10.0",
+  "version": "12.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tradeshift/tradeshift-ui",
-      "version": "12.10.0",
+      "version": "12.10.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradeshift/tradeshift-ui",
-  "version": "12.10.0",
+  "version": "12.10.1",
   "description": "The Tradeshift UI Library & Framework",
   "homepage": "https://ui.tradeshift.com/",
   "bugs": {

--- a/src/runtime/less/ts-forms.less
+++ b/src/runtime/less/ts-forms.less
@@ -759,28 +759,28 @@
 		&,
 		&.ts-1-1 {
 			label {
-				width: 100%/2;
+				width: (100%/2);
 			}
 		}
 		&.ts-1-2 {
 			label:nth-child(1) {
-				width: 100%/3;
+				width: (100%/3);
 			}
 			label:nth-child(2) {
-				width: 100%/1.5;
+				width: (100%/1.5);
 			}
 		}
 		&.ts-2-1 {
 			label:nth-child(1) {
-				width: 100%/1.5;
+				width: (100%/1.5);
 			}
 			label:nth-child(2) {
-				width: 100%/3;
+				width: (100%/3);
 			}
 		}
 		&.ts-1-1-1 {
 			label {
-				width: 100%/3;
+				width: (100%/3);
 				&:nth-child(2) + label {
 					display: inline-block;
 				}


### PR DESCRIPTION
## Summary
- `ts-forms.less` had several `width: 100%/N` declarations without parentheses. Less 3+ only evaluates math inside parentheses, so these were passed through to CSS literally as `100%/2` etc., which browsers don't recognize as a valid value (the declaration is dropped as invalid).
- Wrapped each expression in parens (`width: (100%/2)`) so Less computes the percentage at build time.

## Test plan
- [x] Verified with the project's `less@4.6.7` in isolation that `(100%/2)` compiles to `50%` while the unparenthesized form is passed through unchanged
- [x] `npm run build` succeeds